### PR TITLE
[DISCUSS] allow rspec as a testing framework.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,16 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
 
 task :default => :test
 
 mock = ENV['FOG_MOCK'] || 'true'
-task :test do
-  sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+
+task :test => ["test:shindo", "test:rspec"]
+
+namespace :test do
+  desc 'Run shindo tests'
+  task :shindo do
+    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+  end
+  RSpec::Core::RakeTask.new(:rspec)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 task :default => :test
 
-mock = ENV['FOG_MOCK'] || 'true'
+mock = ENV['FOG_MOCK'] || "true"
 
 task :test => ["test:shindo", "test:rspec"]
 

--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',   '~> 3.1'
   spec.add_development_dependency 'shindo',  '~> 0.3'
 
-  spec.add_dependency 'fog-core',  '~> 1.27'
+  spec.add_dependency 'fog-core',  '~> 1.27', '>= 1.27.3'
   spec.add_dependency 'fog-json',  '~> 1.0'
   spec.add_dependency 'fog-xml',   '~> 0.1'
   spec.add_dependency 'ipaddress', '~> 0.8'

--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake',    '~> 10.0'
+  spec.add_development_dependency 'rspec',   '~> 3.1'
   spec.add_development_dependency 'shindo',  '~> 0.3'
 
   spec.add_dependency 'fog-core',  '~> 1.27'

--- a/lib/fog/aws/models/sns/topic.rb
+++ b/lib/fog/aws/models/sns/topic.rb
@@ -32,12 +32,17 @@ module Fog
         end
 
         def save
-          requires :id
+          requires_one :id, :display_name
 
-          data = service.create_topic(id).body["TopicArn"]
-          if data
-            data = {"id" => data}
-            merge_attributes(data)
+          name = if id
+                   Fog::Logger.deprecation("#{self.class}#save with #id is deprecated, use display_name instead [light_black](#{caller.first})[/]")
+                   id
+                 else
+                   display_name
+                 end
+
+          if identity = service.create_topic(name).body["TopicArn"]
+            merge_attributes("id" => identity)
             true
           else false
           end

--- a/spec/models/sns/topic_spec.rb
+++ b/spec/models/sns/topic_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe "Fog::AWS::SNS::Topic" do
+  before(:all) { @topic = Fog::AWS[:sns].topics.new(display_name: 'fog') }
+  subject      { @topic }
+
+  it "should #save" do
+    expect {
+      subject.save
+    }.to change { subject.id }.from(nil)
+  end
+
+  it "should #update_topic_attribute" do
+    expect {
+      subject.update_topic_attribute("DisplayName", "new-fog")
+    }.to change { subject.display_name }.to("new-fog")
+  end
+
+  it "should #destroy" do
+    expect {
+      subject.destroy
+    }.to change { subject.reload }.to(nil)
+  end
+end

--- a/spec/models/sns/topics_spec.rb
+++ b/spec/models/sns/topics_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe "Fog::AWS::SNS::Topics", :sns do
+  include_examples "collection", Fog::AWS[:sns].topics, {:name => 'fog'}
+end

--- a/spec/models/sns/topics_spec.rb
+++ b/spec/models/sns/topics_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe "Fog::AWS::SNS::Topics", :sns do
-  include_examples "collection", Fog::AWS[:sns].topics, {:name => 'fog'}
+  include_examples "collection", Fog::AWS[:sns].topics, {:display_name => 'fog'}
 end

--- a/spec/shared/collection.rb
+++ b/spec/shared/collection.rb
@@ -1,0 +1,67 @@
+shared_examples "collection" do |collection, params|
+  it "should create a new #{collection.model}" do
+    collection.new(params)
+  end
+
+  context "with a #{collection.model}" do
+    before(:all) {
+      @resource = collection.create(params)
+
+      if Fog.mocking? && @resource.respond_to?(:ready?)
+        @resource.wait_for { ready? }
+      end
+    }
+    subject     { @resource }
+    after(:all) { @resource && @resource.destroy }
+
+    it "should #get" do
+      expect(
+        collection.get(subject.identity).identity
+      ).to eq(subject.identity)
+    end
+
+    it "should not #get an invalid record" do
+      identity = subject.identity.to_s
+      identity = identity.gsub(/[a-zA-Z]/) { Fog::Mock.random_letters(1) }
+      identity = identity.gsub(/\d/)       { Fog::Mock.random_numbers(1) }
+
+      expect(collection.get(identity)).to be_nil
+    end
+
+    context "Enumberable" do
+      methods = [
+        'all?', 'any?', 'find',  'detect', 'collect', 'map',
+        'find_index', 'flat_map', 'collect_concat', 'group_by',
+        'none?', 'one?'
+      ]
+
+      # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
+      # https://github.com/jruby/jruby/issues/1265
+      if RUBY_PLATFORM == "java" and JRUBY_VERSION =~ /1\.7\.[5-8]/
+        methods.delete('all?')
+      end
+
+      methods.each do |enum_method|
+        if collection.respond_to?(enum_method)
+          it "should call ##{enum_method}" do
+            skip unless collection.respond_to?(enum_method)
+            block_called = false
+            collection.send(enum_method) {|x| block_called = true }
+            expect(block_called).to eq(true)
+          end
+        end
+      end
+
+      [
+        'max_by','min_by'
+      ].each do |enum_method|
+        it "should call ##{enum_method}" do
+          skip unless collection.respond_to?(enum_method)
+          block_called = false
+          collection.send(enum_method) {|x| block_called = true }
+          expect(block_called).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+ENV['FOG_MOCK'] ||= 'true'
+
+begin
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+rescue LoadError => e
+  $stderr.puts "not recording test coverage: #{e.inspect}"
+end
+
+Bundler.require(:test)
+
+require File.expand_path("../../lib/fog/aws", __FILE__)
+require File.expand_path("../../tests/helpers/mock_helper", __FILE__)
+Excon.defaults.merge!(debug_request: true, debug_response: true)
+Dir[File.expand_path("../{shared,support}/*.rb", __FILE__)].each { |f| require(f) }
+
+# This overrides the default 600 seconds timeout during live test runs
+if Fog.mocking?
+  Fog.timeout = ENV['FOG_TEST_TIMEOUT'] || 2000
+  Fog::Logger.warning "Setting default fog timeout to #{Fog.timeout} seconds"
+end
+
+RSpec.configure do |config|
+  config.filter_run_excluding(:not_mocked) if Fog.mocking?
+end


### PR DESCRIPTION
  Per the discussion https://github.com/fog/fog/issues/1266, this is an example of what an rspec collection and model test would entail.

  The biggest issue I can see is that in order to facilitate shindo's 'one resource per suite', you have to do a ` before(:all)` (frowned upon) with an instance variable and then a subject reference to the instance variable.  In order to fit the more modern take on reseting state before each example, we could easily move the setup to a `before(:each)` but it would blow out the time for testing against a real provider.

  Huge wins are the tagging, the command line execution of examples via filters, and also the community familiarity.

