### PR TITLE
fix autoscaling activities collection setup

### DIFF
--- a/lib/fog/aws/models/auto_scaling/activities.rb
+++ b/lib/fog/aws/models/auto_scaling/activities.rb
@@ -10,8 +10,8 @@ module Fog
 
         # Creates a new scaling policy.
         def initialize(attributes={})
-          self.filters = attributes
-          super(attributes)
+          self.filters ||= {}
+          super
         end
 
         def all(filters_arg = filters)

--- a/lib/fog/aws/models/auto_scaling/group.rb
+++ b/lib/fog/aws/models/auto_scaling/group.rb
@@ -42,19 +42,8 @@ module Fog
 
         def activities
           requires :id
-          data = []
-          next_token = nil
-          loop do
-            result = service.describe_scaling_activities('AutoScalingGroupName' => id, 'NextToken' => next_token).body['DescribeScalingActivitiesResult']
-            data += result['Activities']
-            next_token = result['NextToken']
-            break if next_token.nil?
-          end
-          Fog::AWS::AutoScaling::Activities.new({
-            :data => data,
-            :service => service,
-            #:load_balancer => self
-          })
+
+          activities = Fog::AWS::AutoScaling::Activities.new(:service => service, :filters => {'AutoScalingGroupName' => id})
         end
 
         def configuration


### PR DESCRIPTION
The AutoScaling#Group.activities method was doing something very strange - loading the collection rather than letting it load itself.

The activities model itself was also doing something very strange since it was assuming that all the arguments passed to it were filters, whereas we need to pass in the service (and since filters are dumped straight into the request parameters this caused an exception in the request signing code).

I'm not super familiar with the Fog::Collection stuff, but I think this is closer to what it should do (and does actually work).