### PR TITLE
BUGFIX: When fog_credentials endpoint is set @region defaults to nil

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -365,17 +365,21 @@ module Fog
 
         def initialize(options={})
           @use_iam_profile = options[:use_iam_profile]
+
+          @region = options[:region] || DEFAULT_REGION
+
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
             @host = endpoint.host
             @scheme = endpoint.scheme
             @port = endpoint.port
           else
-            @region     = options[:region]      || DEFAULT_REGION
             @host       = options[:host]        || region_to_host(@region)
             @scheme     = options[:scheme]      || DEFAULT_SCHEME
             @port       = options[:port]        || DEFAULT_SCHEME_PORT[@scheme]
           end
+
+
           @path_style = options[:path_style] || false
           setup_credentials(options)
         end
@@ -430,13 +434,14 @@ module Fog
           validate_signature_version!
           @path_style = options[:path_style]  || false
 
+          @region = options[:region] || DEFAULT_REGION
+
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
             @host = endpoint.host
             @scheme = endpoint.scheme
             @port = endpoint.port
           else
-            @region     = options[:region]      || DEFAULT_REGION
             @host       = options[:host]        || region_to_host(@region)
             @scheme     = options[:scheme]      || DEFAULT_SCHEME
             @port       = options[:port]        || DEFAULT_SCHEME_PORT[@scheme]


### PR DESCRIPTION
This PR attempts to address the following issue:

**TypeError - no implicit conversion of nil into String**
https://github.com/fog/fog/issues/3300

Previous PR's and commits have attempted to provide a solution:
- https://github.com/fog/fog/commit/46a7a47d043169e52f4ab6ee676613cad08b0690
- https://github.com/fog/fog-aws/pull/2

Taking a look at https://github.com/fog/fog-aws/blob/master/lib/fog/aws/storage.rb

It seems like if `options[:endpoint]` is set then `@region` will be nil when passed into `Fog::AWS::SignatureV4.new( @aws_access_key_id, @aws_secret_access_key, @region, 's3')`
ref: https://github.com/fog/fog-aws/blob/master/lib/fog/aws/storage.rb#L467

This PR suggests defaulting `@region` at the outset to avoid the issue of it being nil

Is there a reason `@region` should be nil if `options[:endpoint]`is set?

This PR completely resolves the `TypeError` for me.

Here's is my config and stack trace for reference:

```
* fog (1.27.0)
* fog-aws (0.0.6 4c7bf1d)

ruby '2.1.5'
rails, '4.1.8'


CarrierWave.configure do |config|
    config.storage = :fog
    config.fog_credentials = {
      provider:              'AWS',
      aws_access_key_id:     'access_key',
      aws_secret_access_key: 'secret_key',
      endpoint:              "https://s3.amazonaws.com"
    }
    config.fog_directory  = 'bucket1'
    config.fog_public     = true
  end
```

```
TypeError: no implicit conversion of nil into String
[GEM_ROOT]/gems/fog-core-1.25.0/lib/fog/core/hmac.rb:29 :in `digest`
[GEM_ROOT]/gems/fog-core-1.25.0/lib/fog/core/hmac.rb:29 :in `block in setup_sha256`
[GEM_ROOT]/gems/fog-core-1.25.0/lib/fog/core/hmac.rb:14 :in `call`
[GEM_ROOT]/gems/fog-core-1.25.0/lib/fog/core/hmac.rb:14 :in `sign`
[GEM_ROOT]/gems/fog-1.25.0/lib/fog/aws/signaturev4.rb:68 :in `derived_hmac`
[GEM_ROOT]/gems/fog-1.25.0/lib/fog/aws/signaturev4.rb:56 :in `signature_components`
[GEM_ROOT]/gems/fog-1.25.0/lib/fog/aws/storage.rb:501 :in `request`
[GEM_ROOT]/gems/fog-1.25.0/lib/fog/aws/requests/storage/put_object.rb:31 :in `put_object`
[GEM_ROOT]/gems/fog-1.25.0/lib/fog/aws/models/storage/file.rb:208 :in `save`
[GEM_ROOT]/gems/fog-core-1.25.0/lib/fog/core/collection.rb:50 :in `create`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/storage/fog.rb:261 :in `store`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/storage/fog.rb:80 :in `store!`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/uploader/store.rb:59 :in `block in store!`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/uploader/callbacks.rb:17 :in `with_callbacks`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/uploader/store.rb:58 :in `store!`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/mount.rb:375 :in `store!`
[GEM_ROOT]/gems/carrierwave-0.10.0/lib/carrierwave/mount.rb:207 :in `store_avatar!`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:424 :in `block in make_lambda`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:221 :in `call`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:221 :in `block in halting_and_conditional`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:215 :in `call`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:215 :in `block in halting_and_conditional`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:215 :in `call`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:215 :in `block in halting_and_conditional`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:86 :in `call`
[GEM_ROOT]/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:86 :in `run_callbacks`
[GEM_ROOT]/gems/mongoid-4.0.0/lib/mongoid/interceptable.rb:138 :in `run_callbacks`
[GEM_ROOT]/gems/mongoid-4.0.0/lib/mongoid/persistable/updatable.rb:115 :in `prepare_update`
[GEM_ROOT]/gems/mongoid-4.0.0/lib/mongoid/persistable/updatable.rb:138 :in `update_document`
[GEM_ROOT]/gems/mongoid-4.0.0/lib/mongoid/persistable/savable.rb:25 :in `save`
[GEM_ROOT]/gems/mongoid-4.0.0/lib/mongoid/persistable/updatable.rb:52 :in `update`
```