### PR TITLE
[AWS|Autoscaling] Add missing ebs attributes to describe_launch_configurations

### DIFF
--- a/lib/fog/aws/parsers/auto_scaling/describe_launch_configurations.rb
+++ b/lib/fog/aws/parsers/auto_scaling/describe_launch_configurations.rb
@@ -49,7 +49,7 @@ module Fog
             when 'DeviceName', 'VirtualName'
               @block_device_mapping[name] = value
 
-            when 'SnapshotId', 'VolumeSize'
+            when 'SnapshotId', 'VolumeSize', 'VolumeType', 'Iops'
               @ebs[name] = value
             when 'Ebs'
               @block_device_mapping[name] = @ebs


### PR DESCRIPTION
Should address #18