### PR TITLE
Allow for AWS errors not specifying region

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -554,7 +554,7 @@ module Fog
             new_params[:bucket_name] =  %r{<Bucket>([^<]*)</Bucket>}.match(body).captures.first
             new_params[:host] = %r{<Endpoint>([^<]*)</Endpoint>}.match(body).captures.first
             # some errors provide it directly
-            @new_region = %r{<Region>([^<]*)</Region>}.match(body).captures.first
+            @new_region = %r{<Region>([^<]*)</Region>}.match(body) ? Regexp.last_match.captures.first : nil
           end
           Fog::Logger.warning("fog: followed redirect to #{host}, connecting to the matching region will be more performant")
           original_region, original_signer = @region, @signer


### PR DESCRIPTION
We're getting ```"undefined method `captures' for nil:NilClass"``` when sending requests with the wrong region. This PR updates the error parsing to handle the case where a new region isn't specified (the comment above this line suggests only some errors explicitly provide it).