### PR TITLE
Add idempotent excon option to some route53 API calls

### DIFF
--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -141,6 +141,7 @@ module Fog
           body = %Q{<?xml version="1.0" encoding="UTF-8"?><ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/#{@version}/">#{changes}</ChangeResourceRecordSetsRequest>}
           request({
             :body       => body,
+            :idempotent => true,
             :parser     => Fog::Parsers::DNS::AWS::ChangeResourceRecordSets.new,
             :expects    => 200,
             :method     => 'POST',

--- a/lib/fog/aws/requests/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/get_hosted_zone.rb
@@ -27,8 +27,9 @@ module Fog
 
           request({
             :expects => 200,
-            :parser  => Fog::Parsers::DNS::AWS::GetHostedZone.new,
+            :idempotent => true,
             :method  => 'GET',
+            :parser  => Fog::Parsers::DNS::AWS::GetHostedZone.new,
             :path    => "hostedzone/#{zone_id}"
           })
         end

--- a/lib/fog/aws/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/list_resource_record_sets.rb
@@ -48,11 +48,12 @@ module Fog
           end
 
           request({
-            :query   => parameters,
-            :parser  => Fog::Parsers::DNS::AWS::ListResourceRecordSets.new,
             :expects => 200,
+            :idempotent => true,
             :method  => 'GET',
-            :path    => "hostedzone/#{zone_id}/rrset"
+            :parser  => Fog::Parsers::DNS::AWS::ListResourceRecordSets.new,
+            :path    => "hostedzone/#{zone_id}/rrset",
+            :query   => parameters
           })
         end
       end


### PR DESCRIPTION
This PR add `idempotent` attribute to underlying request calls to retry in case AWS throws a 400 error.

Affected API calls:

- ChangeResourceRecordSetsRequest
- GetHostedZone
- ListResourceRecordSets