### PR TITLE
Add support for cname buckets

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -256,21 +256,25 @@ module Fog
           if params[:bucket_name]
             bucket_name = params[:bucket_name]
 
-            path_style = params.fetch(:path_style, @path_style)
-            if !path_style
-              if COMPLIANT_BUCKET_NAMES !~ bucket_name
-                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-                path_style = true
-              elsif scheme == 'https' && !path_style && bucket_name =~ /\./
-                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-                path_style = true
-              end
-            end
-
-            if path_style
-              path = bucket_to_path bucket_name, path
+            if params[:bucket_cname]
+              host = bucket_name
             else
-              host = [bucket_name, host].join('.')
+              path_style = params.fetch(:path_style, @path_style)
+              if !path_style
+                if COMPLIANT_BUCKET_NAMES !~ bucket_name
+                  Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                  path_style = true
+                elsif scheme == 'https' && !path_style && bucket_name =~ /\./
+                  Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                  path_style = true
+                end
+              end
+
+              if path_style
+                path = bucket_to_path bucket_name, path
+              else
+                host = [bucket_name, host].join('.')
+              end
             end
           end
 


### PR DESCRIPTION
Ported from fog/fog#3140.

This allows users to pass `bucket_cname: true` and have the url be generated as per http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingCustomURLs

If this is missing tests, documentation, please let me know where and how it should be done. I couldn't find out much from the contributing guidelines. Thanks