### PR TITLE
Mock method for AWS S3 post_object_hidden_fields 

### DIFF
--- a/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
+++ b/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
@@ -46,7 +46,35 @@ module Fog
             end
             options['X-Amz-Signature'] = @signer.derived_hmac(date).sign(options['policy']).unpack('H*').first
           end
-          options          
+          options
+        end
+      end
+      class Mock
+        def post_object_hidden_fields(options = {})
+          options = options.dup
+          if policy = options['policy']
+            date = Fog::Time.now
+            credential = "#{@aws_access_key_id}/#{@signer.credential_scope(date)}"
+            extra_conditions = [
+              {'x-amz-date' => date.to_iso8601_basic},
+              {'x-amz-credential' => credential},
+              {'x-amz-algorithm' => Fog::AWS::SignatureV4::ALGORITHM}
+            ]
+
+            extra_conditions << {'x-amz-security-token' => @aws_session_token } if @aws_session_token
+
+            policy_with_auth_fields = policy.merge('conditions' => policy['conditions'] + extra_conditions)
+
+            options['policy'] = Base64.encode64(Fog::JSON.encode(policy_with_auth_fields)).gsub("\n", "")
+            options['X-Amz-Credential'] = credential
+            options['X-Amz-Date'] = date.to_iso8601_basic
+            options['X-Amz-Algorithm'] = Fog::AWS::SignatureV4::ALGORITHM
+            if @aws_session_token
+              options['X-Amz-Security-Token'] = @aws_session_token
+            end
+            options['X-Amz-Signature'] = @signer.derived_hmac(date).sign(options['policy']).unpack('H*').first
+          end
+          options
         end
       end
     end


### PR DESCRIPTION
Hi,

` post_object_hidden_fields ` doesn't make any external call, can be used as Mock method. Tell me if there a more elegant way to do this instead of copy & paste.