### PR TITLE
Stringify keys for query parameters

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -536,6 +536,7 @@ module Fog
           date = Fog::Time.now
 
           params = params.dup
+          params = stringify_query_keys(params)
           params[:headers] = (params[:headers] || {}).dup
 
           params[:headers]['x-amz-security-token'] = @aws_session_token if @aws_session_token
@@ -732,6 +733,10 @@ DATA
           string_to_sign << canonical_resource
           signed_string = @hmac.sign(string_to_sign)
           Base64.encode64(signed_string).chomp!
+        end
+
+        def stringify_query_keys(params)
+          params[:query] = Hash[params[:query].map { |k,v| [k.to_s, v] }]
         end
       end
     end


### PR DESCRIPTION
* The query hash expects that all keys are strings. If the query hash
  has both string and symbol keys the `signature_v2` method raises an
  exception
* The query hash is often the leftover keys that have not been
  extracted from the initial request.
* The conversion of sym -> string is done elsewhere for other parameters
* Makes the request more robust in general.