### PR TITLE
Fix EC2 security groups where SSH inbound rule isn't first

### DIFF
--- a/lib/fog/aws/models/compute/servers.rb
+++ b/lib/fog/aws/models/compute/servers.rb
@@ -195,7 +195,7 @@ module Fog
 
           # make sure port 22 is open in the first security group
           authorized = security_group.ip_permissions.find do |ip_permission|
-            ip_permission['ipRanges'].first && ip_permission['ipRanges'].first['cidrIp'] == '0.0.0.0/0' &&
+            ip_permission['ipRanges'].find { |ip_range| ip_range['cidrIp'] == '0.0.0.0/0' } &&
             ip_permission['fromPort'] == 22 &&
             ip_permission['ipProtocol'] == 'tcp' &&
             ip_permission['toPort'] == 22


### PR DESCRIPTION
Issue with provisioning EC2 instances where security group's SSH inbound 0.0.0.0/0 permission is not at index 0.

**Repro:**

1. Create security group "Foo" with rule: Allow inbound port 22 from your IP.
1. Start an instance with connection.servers.bootstrap, groups: ["Foo"]
1. Observe Foo. Notice that fog-aws adds the rule SSH inbound 0.0.0.0/0, and it's at index 1.
1. Start another instance with the same arguments.
1. Error is `gems/excon-0.44.4/lib/excon/middlewares/expects.rb:6:in `response_call': Duplicate => the specified rule \"peer: 0.0.0.0/0, TCP, from port: 22, to port: 22, ALLOW\" already exists (Fog::Compute::AWS::Error)` from [fog/aws/models/compute/servers.rb:205](https://github.com/fog/fog-aws/blob/master/lib/fog/aws/models/compute/servers.rb#L205)

This fixes it by checking all ip ranges, not just the first one.