### PR TITLE
Resource record sets bug fix + support eu-central-1 

### DIFF
--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -222,9 +222,9 @@ module Fog
       end
 
       def self.hosted_zone_for_alias_target(dns_name)
-        elb_hosted_zone_mapping.select { |k, _|
+        Hash[elb_hosted_zone_mapping.select { |k, _|
           dns_name =~ /\A.+\.#{k}\.elb\.amazonaws\.com\.?\z/
-        }.values.last
+        }].values.last
       end
 
       def self.elb_hosted_zone_mapping

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -224,7 +224,7 @@ module Fog
       def self.hosted_zone_for_alias_target(dns_name)
         elb_hosted_zone_mapping.select { |k, _|
           dns_name =~ /\A.+\.#{k}\.elb\.amazonaws\.com\.?\z/
-        }.last
+        }.values.last
       end
 
       def self.elb_hosted_zone_mapping

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -233,6 +233,7 @@ module Fog
           "ap-southeast-1" => "Z1WI8VXHPB1R38",
           "ap-southeast-2" => "Z2999QAZ9SRTIC",
           "eu-west-1"      => "Z3NF1Z3NOM5OY2",
+          "eu-central-1"   => "Z215JYRZR1TBD5",
           "sa-east-1"      => "Z2ES78Y61JGQKS",
           "us-east-1"      => "Z3DZXE0Q79N41H",
           "us-west-1"      => "Z1M58G0W56PQJA",

--- a/tests/requests/dns/change_resource_record_sets_tests.rb
+++ b/tests/requests/dns/change_resource_record_sets_tests.rb
@@ -1,0 +1,10 @@
+Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
+  @r53_connection = Fog::DNS[:aws]
+
+  tests('success') do
+    test('#elb_hosted_zone_mapping from DNS name') do
+      zone_id = Fog::DNS::AWS.hosted_zone_for_alias_target('arbitrary-sub-domain.eu-west-1.elb.amazonaws.com')
+      zone_id == Fog::DNS::AWS.elb_hosted_zone_mapping['eu-west-1']
+    end
+  end
+end


### PR DESCRIPTION
Fixes a an error `undefined method `last' for {"eu-west-1"=>"Z3NF1Z3NOM5OY2"}:Hash` when using the `change_resource_record_sets` method.

Also added support for the new eu-central-1 region