### PR TITLE
Fix for `undefined method `map' for nil:NilClass`

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -536,7 +536,7 @@ module Fog
           date = Fog::Time.now
 
           params = params.dup
-          params = stringify_query_keys(params)
+          stringify_query_keys(params)
           params[:headers] = (params[:headers] || {}).dup
 
           params[:headers]['x-amz-security-token'] = @aws_session_token if @aws_session_token
@@ -736,7 +736,7 @@ DATA
         end
 
         def stringify_query_keys(params)
-          params[:query] = Hash[params[:query].map { |k,v| [k.to_s, v] }]
+          params[:query] = Hash[params[:query].map { |k,v| [k.to_s, v] }] if params[:query]
         end
       end
     end


### PR DESCRIPTION
1e799c59187702650253000f80bed67e422acc5f expects that params[:query] is always defined, and also introduced another bug that reassigned params incorrectly