### PR TITLE
[rds] prevent final snapshot on replicas

### DIFF
--- a/lib/fog/aws/requests/rds/create_db_snapshot.rb
+++ b/lib/fog/aws/requests/rds/create_db_snapshot.rb
@@ -30,6 +30,7 @@ module Fog
           end
 
           server_data = data[:servers][identifier]
+
           unless server_data
             raise Fog::AWS::RDS::NotFound.new("DBInstance #{identifier} not found")
           end

--- a/tests/models/rds/server_tests.rb
+++ b/tests/models/rds/server_tests.rb
@@ -1,7 +1,4 @@
 Shindo.tests("AWS::RDS | server", ['aws', 'rds']) do
-  # Disabled due to https://github.com/fog/fog/1546
-  pending
-
   model_tests(Fog::AWS[:rds].servers, rds_default_server_params) do
     # We'll need this later; create it early to avoid waiting
     @instance_with_final_snapshot = Fog::AWS[:rds].servers.create(rds_default_server_params.merge(:id => uniq_id("fog-snapshot-test"), :backup_retention_period => 1))
@@ -89,6 +86,10 @@ Shindo.tests("AWS::RDS | server", ['aws', 'rds']) do
       returns(@instance_with_final_snapshot.id) { replica.read_replica_source }
 
       replica.wait_for { ready? }
+
+      # FinalDBSnapshotIdentifier can not be specified when deleting a replica instance
+      raises(Fog::AWS::RDS::Error) { replica.destroy("foobar") }
+
       replica.destroy
     end
 


### PR DESCRIPTION
* `InvalidParameterCombination => FinalDBSnapshotIdentifier can not be specified when deleting a replica instance`