### PR TITLE
Handle missing parameters in describe_spot_price_history request

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_spot_price_history.rb
+++ b/lib/fog/aws/parsers/compute/describe_spot_price_history.rb
@@ -15,7 +15,7 @@ module Fog
             when 'item'
               @response['spotPriceHistorySet'] << @spot_price
               @spot_price = {}
-            when 'requestId'
+            when 'requestId', 'nextToken'
               @response[name] = value
             when 'spotPrice'
               @spot_price[name] = value.to_f

--- a/lib/fog/aws/requests/compute/describe_spot_price_history.rb
+++ b/lib/fog/aws/requests/compute/describe_spot_price_history.rb
@@ -8,6 +8,14 @@ module Fog
         #
         # ==== Parameters
         # * filters<~Hash> - List of filters to limit results with
+        #   * filters and/or the following
+        #     * 'AvailabilityZone'<~String> - availability zone of offering
+        #     * 'InstanceType'<~Array> - instance types of offering
+        #     * 'ProductDescription'<~Array> - basic product descriptions
+        #     * 'StartTime'<~Time> - The date and time, up to the past 90 days, from which to start retrieving the price history data
+        #     * 'EndTime'<~Time> - The date and time, up to the current date, from which to stop retrieving the price history data
+        #     * 'MaxResults'<~Integer> - The maximum number of results to return for the request in a single page
+        #     * 'NextToken'<~String> - The token to retrieve the next page of results
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -19,10 +27,28 @@ module Fog
         #       * 'productDescription'<~String> - general description of AMI
         #       * 'spotPrice'<~Float> - maximum price to launch one or more instances
         #       * 'timestamp'<~Time> - date and time of request creation
+        #     * 'nextToken'<~String> - token to retrieve the next page of results
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSpotPriceHistory.html]
         def describe_spot_price_history(filters = {})
-          params = Fog::AWS.indexed_filters(filters)
+          params = {}
+
+          for key in %w(AvailabilityZone StartTime EndTime MaxResults NextToken)
+            if filters.is_a?(Hash) && filters.key?(key)
+              params[key] = filters.delete(key)
+            end
+          end
+
+          if instance_types = filters.delete('InstanceType')
+            params.merge!(Fog::AWS.indexed_param('InstanceType', [*instance_types]))
+          end
+
+          if product_descriptions = filters.delete('ProductDescription')
+            params.merge!(Fog::AWS.indexed_param('ProductDescription', [*product_descriptions]))
+          end
+
+          params.merge!(Fog::AWS.indexed_filters(filters))
+
           request({
             'Action'    => 'DescribeSpotPriceHistory',
             :idempotent => true,

--- a/tests/requests/compute/spot_price_history_tests.rb
+++ b/tests/requests/compute/spot_price_history_tests.rb
@@ -8,7 +8,8 @@ Shindo.tests('Fog::Compute[:aws] | spot price history requests', ['aws']) do
       'productDescription'  => String,
       'timestamp'           => Time
     }],
-    'requestId' => String
+    'requestId' => String,
+    'nextToken' => Fog::Nullable::String
   }
 
   tests('success') do


### PR DESCRIPTION
Hi folks,

I noticed I couldn't pass some parameters to EC2 DescribeSpotPriceHistory action, so I changed the parameters handling for this function. Without my changes, I was unable to find a way to properly filter the spot prices history as is described in the API documentation.

Thanks,