### PR TITLE
Adding instanceTenancy to reserved instance parser.

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
@@ -26,7 +26,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state', 'offeringType'
+            when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state', 'offeringType', 'instanceTenancy'
               @reserved_instance[name] = value
             when 'duration', 'instanceCount'
               @reserved_instance[name] = value.to_i


### PR DESCRIPTION
Simple change adding one field to the reserved instance parser. Field is present on response per: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeReservedInstances.html