### PR TITLE
ami: Show CreationDate of AMIs.

### DIFF
--- a/lib/fog/aws/models/compute/image.rb
+++ b/lib/fog/aws/models/compute/image.rb
@@ -22,6 +22,7 @@ module Fog
         attribute :tags,                  :aliases => 'tagSet'
         attribute :name
         attribute :virtualization_type,   :aliases => 'virtualizationType'
+        attribute :creation_date,         :aliases => 'creationDate'
 
         def deregister(delete_snapshot = false)
           service.deregister_image(id)

--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -21,6 +21,7 @@ module Fog
         #     * 'imagesSet'<~Array>:
         #       * 'architecture'<~String> - Architecture of the image
         #       * 'blockDeviceMapping'<~Array> - An array of mapped block devices
+        #       * 'creationDate'<~Date> - Creation date of image
         #       * 'description'<~String> - Description of image
         #       * 'imageId'<~String> - Id of the image
         #       * 'imageLocation'<~String> - Location of the image
@@ -92,7 +93,8 @@ module Fog
             'root-device-name'    => 'rootDeviceName',
             'root-device-type'    => 'rootDeviceType',
             'state'               => 'imageState',
-            'virtualization-type' => 'virtualizationType'
+            'virtualization-type' => 'virtualizationType',
+            'creation_date'       => 'creationDate'
           }
 
           image_set = visible_images.values


### PR DESCRIPTION
Hey hey, CreationDate has been available on AMIs for some time. I believe this will expose it to `Fog::Compute::AWS::Image` objects.
