### PR TITLE
Fix v4 signature when path has leading or trailing repeated slashes

### DIFF
--- a/lib/fog/aws/signaturev4.rb
+++ b/lib/fog/aws/signaturev4.rb
@@ -79,8 +79,6 @@ DATA
       protected
 
       def canonical_path(path)
-        #leading and trailing repeated slashes are collapsed, but not ones that appear elsewhere
-        path = path.gsub(%r{\A/+},'/').gsub(%r{/+\z},'/')
         components = path.split('/',-1)
         path = components.inject([]) do |acc, component|
           case component

--- a/tests/signaturev4_tests.rb
+++ b/tests/signaturev4_tests.rb
@@ -58,7 +58,7 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
 
   tests('get with repeated / ') do
     returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '//'}, @now)) do
-      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=ed90a993076c9d2289f0942851cefcca04936604d925e4e3d627a046d308efbe'
     end
   end
 
@@ -70,7 +70,7 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
 
   tests('get with repeated trailing / ') do
     returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '//foo//'}, @now)) do
-      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b00392262853cfe3201e47ccf945601079e9b8a7f51ee4c3d9ee4f187aa9bf19'
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=bed02f23a9182c784fe39dc70f6181f1e50865f2772623c2b245c22bb04ad82c'
     end
   end
 

--- a/tests/signaturev4_tests.rb
+++ b/tests/signaturev4_tests.rb
@@ -44,6 +44,86 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
     end
   end
 
+  tests('get-relative-relative') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/foo/bar/../..'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
+    end
+  end
+
+  tests('get-relative') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/foo/..'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
+    end
+  end
+
+  tests('get-slash-dot-slash') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/./'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
+    end
+  end
+
+  tests('get-slash-pointless-dot') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/./foo'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=910e4d6c9abafaf87898e1eb4c929135782ea25bb0279703146455745391e63a'
+    end
+  end
+
+  tests('get-space') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/%20/foo'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=f309cfbd10197a230c42dd17dbf5cca8a0722564cb40a872d25623cfa758e374'
+    end
+  end
+
+  tests('get-utf8') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/%E1%88%B4'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=8d6634c189aa8c75c2e51e106b6b5121bed103fdb351f7d7d4381c738823af74'
+    end
+  end
+
+  tests('get-vanilla-empty-query-key') do
+    returns(@signer.sign({:query => {'foo' => 'bar'}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=56c054473fd260c13e4e7393eb203662195f5d4a1fada5314b8b52b23f985e9f'
+    end
+  end
+
+  tests('get-vanilla-query-unreserved') do
+    returns(@signer.sign({:query => { '-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz' => '-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=f1498ddb4d6dae767d97c466fb92f1b59a2c71ca29ac954692663f9db03426fb'
+    end
+  end
+
+  tests('post-header-key-case') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'DATE' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :post, :path => '/'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726'
+    end
+  end
+
+  tests('post-header-key-sort') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'DATE' => 'Mon, 09 Sep 2011 23:36:00 GMT', 'ZOO' => 'zoobar'}, :method => :post, :path => '/'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=b7a95a52518abbca0964a999a880429ab734f35ebbf1235bd79a5de87756dc4a'
+    end
+  end
+
+  tests('post-header-value-case') do
+    returns(@signer.sign({:headers => {'host' => 'host.foo.com', 'DATE' => 'Mon, 09 Sep 2011 23:36:00 GMT', 'zoo' => 'ZOOBAR'}, :method => :post, :path => '/'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=273313af9d0c265c531e11db70bbd653f3ba074c1009239e8559d3987039cad7'
+    end
+  end
+
+  tests('post-x-www-form-urlencoded-parameters') do
+    returns(@signer.sign({:headers => {'Content-type' => 'application/x-www-form-urlencoded; charset=utf8', 'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :post, :path => '/',
+                          :body => 'foo=bar'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host, Signature=b105eb10c6d318d2294de9d49dd8b031b55e3c3fe139f2e637da70511e9e7b71'
+    end
+  end
+
+  tests('post-x-www-form-urlencoded') do
+    returns(@signer.sign({:headers => {'Content-type' => 'application/x-www-form-urlencoded', 'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :post, :path => '/',
+                          :body => 'foo=bar'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host, Signature=5a15b22cf462f047318703b92e6f4f38884e4a7ab7b1d6426ca46a8bd1c26cbc'
+    end
+  end
+
   tests('get with relative path') do
     returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/foo/bar/../..'}, @now)) do
       'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
@@ -56,8 +136,9 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
     end
   end
 
-  tests('get with repeated / ') do
+  tests('get with repeated / ') do # aws4_testsuite: get-slash
     returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '//'}, @now)) do
+      # aws4_testsuite result: 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470'
       'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=ed90a993076c9d2289f0942851cefcca04936604d925e4e3d627a046d308efbe'
     end
   end
@@ -68,13 +149,14 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
     end
   end
 
-  tests('get with repeated trailing / ') do
+  tests('get with repeated trailing / ') do # aws4_testsuite: get-slashes
     returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '//foo//'}, @now)) do
+      # aws4_testsuite result: 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b00392262853cfe3201e47ccf945601079e9b8a7f51ee4c3d9ee4f187aa9bf19'
       'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=bed02f23a9182c784fe39dc70f6181f1e50865f2772623c2b245c22bb04ad82c'
     end
   end
 
-  tests('get signature as components') do 
+  tests('get signature as components') do
     returns(@signer.signature_parameters({:query => {'a' => 'foo', 'b' => 'foo'}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/'}, @now)) do
       {
         'X-Amz-Algorithm' => 'AWS4-HMAC-SHA256',

--- a/tests/signaturev4_tests.rb
+++ b/tests/signaturev4_tests.rb
@@ -156,6 +156,13 @@ Shindo.tests('AWS | signaturev4', ['aws']) do
     end
   end
 
+  # should return the same result as 'get with repeated trailing / '
+  tests('get-slashes-dot') do
+    returns(@signer.sign({:query => {}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/.//foo//'}, @now)) do
+      'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=bed02f23a9182c784fe39dc70f6181f1e50865f2772623c2b245c22bb04ad82c'
+    end
+  end
+
   tests('get signature as components') do
     returns(@signer.signature_parameters({:query => {'a' => 'foo', 'b' => 'foo'}, :headers => {'Host' => 'host.foo.com', 'Date' => 'Mon, 09 Sep 2011 23:36:00 GMT'}, :method => :get, :path => '/'}, @now)) do
       {


### PR DESCRIPTION
This adds on to fog/fog-aws#46 and fixes more cases of fog/fog#3416 for me.

Feels silly but S3 keys with leading or trailing slashes are valid when creating an S3 item. Previously in Fog 1.15.0 I was able to create files with keys like `/test//save.txt`.

Since upgrading to 1.30.0 with fog-aws 0.2.2, I am seeing the following error:
```
> connection = Fog::Storage.new(FOG_CONFIG)
> storage = connection.directories.get(aws['s3']['bucket_name'])
> storage.files.create(key: "/test//save.txt", body: "this is the body")

Excon::Errors::Forbidden: Expected(200) <=> Actual(403 Forbidden)
excon.error.response
  :body          => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>SignatureDoesNotMatch</Code>
<Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message>
...</Error>"
  :headers       => {
    "Connection"       => "close"
    "Content-Type"     => "application/xml"
    "Date"             => "Sat, 16 May 2015 21:08:25 GMT"
    "Server"           => "AmazonS3"
    "x-amz-id-2"       => "xxx"
    "x-amz-request-id" => "xxx"
  }
  :local_address => "x.x.x.x"
  :local_port    => 56051
  :reason_phrase => "Forbidden"
  :remote_ip     => "x.x.x.x"
  :status        => 403
  :status_line   => "HTTP/1.1 403 Forbidden\r\n"
```

This pull request allows repeated leading and trailing slashes.