### PR TITLE
Update that will allow updating global indexes

### DIFF
--- a/lib/fog/aws/requests/dynamodb/update_table.rb
+++ b/lib/fog/aws/requests/dynamodb/update_table.rb
@@ -27,7 +27,7 @@ module Fog
         #       * 'TableName'<~String> - name of table
         #       * 'TableStatus'<~String> - status of table
         def update_table(table_name, provisioned_throughput, global_indexes=nil)
-          if global_indexes == nil
+          if global_indexes != nil
            body = {
             'GlobalSecondaryIndexUpdates' => global_indexes,
             'ProvisionedThroughput' => provisioned_throughput,

--- a/lib/fog/aws/requests/dynamodb/update_table.rb
+++ b/lib/fog/aws/requests/dynamodb/update_table.rb
@@ -26,15 +26,23 @@ module Fog
         #         * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #       * 'TableName'<~String> - name of table
         #       * 'TableStatus'<~String> - status of table
-        def update_table(table_name, provisioned_throughput)
-          body = {
+        def update_table(table_name, provisioned_throughput, global_indexes=nil)
+          if global_indexes == nil
+           body = {
+            'GlobalSecondaryIndexUpdates' => global_indexes,
             'ProvisionedThroughput' => provisioned_throughput,
             'TableName'             => table_name
-          }
+           }
+          else
+           body = {
+            'ProvisionedThroughput' => provisioned_throughput,
+            'TableName'             => table_name
+           }
+          end
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.UpdateTable'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.UpdateTable'},
             :idempotent => true
           )
         end


### PR DESCRIPTION
Update that will allow updating global indexes.
 def update_table(table_name, provisioned_throughput)
changed to
def update_table(table_name, provisioned_throughput, global_indexes=nil)

where global_indexes should be a hash specified like at http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html
