### PR TITLE
make elb/policies collection standalone

### DIFF
--- a/lib/fog/aws/models/elb/load_balancer.rb
+++ b/lib/fog/aws/models/elb/load_balancer.rb
@@ -143,23 +143,22 @@ module Fog
         end
 
         def listeners
-          Fog::AWS::ELB::Listeners.new({
-            :data => attributes['ListenerDescriptions'],
-            :service => service,
+          Fog::AWS::ELB::Listeners.new(
+            :data          => attributes['ListenerDescriptions'],
+            :service       => service,
             :load_balancer => self
-          })
+          )
         end
 
         def policies
-          Fog::AWS::ELB::Policies.new({
-            :data => policy_descriptions,
-            :service => service,
-            :load_balancer => self
-          })
+          requires :id
+
+          service.policies(:load_balancer_id => self.identity)
         end
 
         def policy_descriptions
           requires :id
+
           @policy_descriptions ||= service.describe_load_balancer_policies(id).body["DescribeLoadBalancerPoliciesResult"]["PolicyDescriptions"]
         end
 
@@ -202,7 +201,7 @@ module Fog
           service.remove_tags(id, tag_keys)
           tags
         end
-        
+
 
         def save
           requires :id

--- a/lib/fog/aws/models/elb/policies.rb
+++ b/lib/fog/aws/models/elb/policies.rb
@@ -24,6 +24,10 @@ module Fog
           all.find { |policy| id == policy.id }
         end
 
+        def new(attributes={})
+          super(self.attributes.merge(attributes))
+        end
+
         private
 
         def munge(data)

--- a/lib/fog/aws/models/elb/policies.rb
+++ b/lib/fog/aws/models/elb/policies.rb
@@ -1,23 +1,33 @@
 require 'fog/aws/models/elb/policy'
+
 module Fog
   module AWS
     class ELB
       class Policies < Fog::Collection
+
+        attribute :load_balancer_id
+
         model Fog::AWS::ELB::Policy
 
-        attr_accessor :data, :load_balancer
+        def all(options={})
+          merge_attributes(options)
 
-        def all
-          load(munged_data)
+          requires :load_balancer_id
+
+          data = service.describe_load_balancer_policies(self.load_balancer_id).
+            body["DescribeLoadBalancerPoliciesResult"]["PolicyDescriptions"]
+
+          load(munge(data))
         end
 
         def get(id)
-          all.find{|policy| id == policy.id}
+          all.find { |policy| id == policy.id }
         end
 
         private
-        def munged_data
-          data.reduce([]){|m,e|
+
+        def munge(data)
+          data.reduce([]) { |m,e|
             policy_attribute_descriptions = e["PolicyAttributeDescriptions"]
 
             policy = {

--- a/lib/fog/aws/models/elb/policies.rb
+++ b/lib/fog/aws/models/elb/policies.rb
@@ -31,9 +31,10 @@ module Fog
             policy_attribute_descriptions = e["PolicyAttributeDescriptions"]
 
             policy = {
-              :id => e["PolicyName"],
-              :type_name => e["PolicyTypeName"],
-              :policy_attributes => policy_attributes(policy_attribute_descriptions)
+              :id                => e["PolicyName"],
+              :type_name         => e["PolicyTypeName"],
+              :policy_attributes => policy_attributes(policy_attribute_descriptions),
+              :load_balancer_id  => self.load_balancer_id,
             }
 
             case e["PolicyTypeName"]

--- a/lib/fog/aws/models/elb/policy.rb
+++ b/lib/fog/aws/models/elb/policy.rb
@@ -8,12 +8,13 @@ module Fog
         attribute :expiration, :aliases => 'CookieExpirationPeriod'
         attribute :type_name
         attribute :policy_attributes
+        attribute :load_balancer_id
 
         attr_accessor :cookie_stickiness # Either :app or :lb
 
         def save
-          requires :id, :load_balancer
-          args = [load_balancer.id, id]
+          requires :id, :load_balancer_id
+          args = [load_balancer_id, id]
 
           if cookie_stickiness
             case cookie_stickiness
@@ -39,13 +40,16 @@ module Fog
         end
 
         def destroy
-          requires :id, :load_balancer
-          service.delete_load_balancer_policy(load_balancer.id, id)
+          requires :identity, :load_balancer_id
+
+          service.delete_load_balancer_policy(self.load_balancer_id, self.identity)
           reload
         end
 
         def load_balancer
-          service.load_balancers.new(identity: collection.load_balancer_id)
+          requires :load_balancer_id
+
+          service.load_balancers.new(:identity => self.load_balancer_id)
         end
       end
     end

--- a/lib/fog/aws/models/elb/policy.rb
+++ b/lib/fog/aws/models/elb/policy.rb
@@ -13,7 +13,6 @@ module Fog
 
         def save
           requires :id, :load_balancer
-          service_method = nil
           args = [load_balancer.id, id]
 
           if cookie_stickiness
@@ -45,12 +44,8 @@ module Fog
           reload
         end
 
-        def reload
-          load_balancer.reload
-        end
-
         def load_balancer
-          collection.load_balancer
+          service.load_balancers.new(identity: collection.load_balancer_id)
         end
       end
     end


### PR DESCRIPTION
* there is no need to inject data from the load balancer model when
  an index request exists that maps directly