### PR TITLE
Make Mock create_vpc method arity match Real

### DIFF
--- a/lib/fog/aws/requests/compute/create_vpc.rb
+++ b/lib/fog/aws/requests/compute/create_vpc.rb
@@ -37,7 +37,7 @@ module Fog
       end
 
       class Mock
-        def create_vpc(cidrBlock)
+        def create_vpc(cidrBlock, options = {})
           Excon::Response.new.tap do |response|
             if cidrBlock
               response.status = 200

--- a/tests/requests/compute/vpc_tests.rb
+++ b/tests/requests/compute/vpc_tests.rb
@@ -52,6 +52,13 @@ Shindo.tests('Fog::Compute[:aws] | vpc requests', ['aws']) do
       data
     end
 
+    tests('#create_vpc').formats(@create_vpcs_format) do
+      data = Fog::Compute[:aws].create_vpc('10.255.254.0/28',
+        {'InstanceTenancy' => 'default'}).body
+      @vpc_id = data['vpcSet'].first['vpcId']
+      data
+    end
+
     tests('#describe_vpcs').formats(@describe_vpcs_format) do
       Fog::Compute[:aws].describe_vpcs.body
     end


### PR DESCRIPTION
This difference in method arity was spuriouly breaking tests that have
nothing to do with those options being passed (InstanceTenancy in my
case).