### PR TITLE
list_hosted_zones expects that options to be hash with symbol as key

### DIFF
--- a/lib/fog/aws/models/dns/zones.rb
+++ b/lib/fog/aws/models/dns/zones.rb
@@ -10,8 +10,8 @@ module Fog
         model Fog::DNS::AWS::Zone
 
         def all(options = {})
-          options['marker']   ||= marker
-          options['maxitems'] ||= max_items
+          options[:marker]   ||= marker
+          options[:maxitems] ||= max_items
           data = service.list_hosted_zones(options).body['HostedZones']
           load(data)
         end


### PR DESCRIPTION
If the hash key is string it won't get applied in list_hosted_zones.