### PR TITLE
The :geo_location attribute needs to be xml formatted before calling aws

### DIFF
--- a/tests/requests/dns/change_resource_record_sets_tests.rb
+++ b/tests/requests/dns/change_resource_record_sets_tests.rb
@@ -19,9 +19,9 @@ Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
         }]
 
     result = Fog::DNS::AWS.change_resource_record_sets_data('zone_id123', change_batch)
-      .match(%r{<GeoLocation>.*</GeoLocation>})
+    geo = result.match(%r{<GeoLocation>.*</GeoLocation>})
     returns("<GeoLocation><CountryCode>US</CountryCode><SubdivisionCode>AR</SubdivisionCode></GeoLocation>") {
-      result ? result[0] : ''
+      geo ? geo[0] : ''
     }
 
     result

--- a/tests/requests/dns/change_resource_record_sets_tests.rb
+++ b/tests/requests/dns/change_resource_record_sets_tests.rb
@@ -7,4 +7,23 @@ Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
       zone_id == Fog::DNS::AWS.elb_hosted_zone_mapping['eu-west-1']
     end
   end
+  tests("#change_resource_record_sets_data formats geolocation properly") do
+    change_batch = [{
+        :action=>"CREATE",
+        :name=>"ark.m.example.net.",
+        :resource_records=>["1.1.1.1"],
+        :ttl=>"300",
+        :type=>"A",
+        :set_identifier=>"ark",
+        :geo_location=>{"CountryCode"=>"US", "SubdivisionCode"=>"AR"},
+        }]
+
+    result = Fog::DNS::AWS.change_resource_record_sets_data('zone_id123', change_batch)
+      .match(%r{<GeoLocation>.*</GeoLocation>})
+    returns("<GeoLocation><CountryCode>US</CountryCode><SubdivisionCode>AR</SubdivisionCode></GeoLocation>") {
+      result ? result[0] : ''
+    }
+
+    result
+  end
 end


### PR DESCRIPTION
Without this, calling `record.destroy` on a record that has geolocation set will cause an exception with:

```
Fog::DNS::AWS::Error: MalformedInput => Unexpected complex element termination
```