### PR TITLE
Adds isDefault to parser for describe_vpcs

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_vpcs.rb
+++ b/lib/fog/aws/parsers/compute/describe_vpcs.rb
@@ -30,7 +30,7 @@ module Fog
               end
             else
               case name
-              when 'vpcId', 'state', 'cidrBlock', 'dhcpOptionsId', 'instanceTenancy'
+              when 'vpcId', 'state', 'cidrBlock', 'dhcpOptionsId', 'instanceTenancy', 'isDefault'
                 @vpc[name] = value
               when 'item'
                 @response['vpcSet'] << @vpc


### PR DESCRIPTION
Missing attribute documented in https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Vpc.html