### PR TITLE
Fix broken xmlns in DNS requests

### DIFF
--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -61,7 +61,7 @@ module Fog
         #     change_resource_record_sets("ABCDEFGHIJKLMN", change_batch_options)
         #
         def change_resource_record_sets(zone_id, change_batch, options = {})
-          body = AWS.change_resource_record_sets_data(zone_id, change_batch, options)
+          body = change_resource_record_sets_data(zone_id, change_batch, @version, options)
           request({
             :body       => body,
             :idempotent => true,
@@ -74,7 +74,7 @@ module Fog
       end
 
       # Returns the xml request for a given changeset
-      def self.change_resource_record_sets_data(zone_id, change_batch, options = {})
+      def self.change_resource_record_sets_data(zone_id, change_batch, version, options = {})
         # AWS methods return zone_ids that looks like '/hostedzone/id'.  Let the caller either use
         # that form or just the actual id (which is what this request needs)
         zone_id = zone_id.sub('/hostedzone/', '')
@@ -153,7 +153,7 @@ module Fog
           changes += '</Changes></ChangeBatch>'
         end
 
-        body = %Q{<?xml version="1.0" encoding="UTF-8"?><ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/#{@version}/">#{changes}</ChangeResourceRecordSetsRequest>}
+        %Q{<?xml version="1.0" encoding="UTF-8"?><ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/#{version}/">#{changes}</ChangeResourceRecordSetsRequest>}
       end
 
       class Mock

--- a/tests/requests/dns/change_resource_record_sets_tests.rb
+++ b/tests/requests/dns/change_resource_record_sets_tests.rb
@@ -7,6 +7,7 @@ Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
       zone_id == Fog::DNS::AWS.elb_hosted_zone_mapping['eu-west-1']
     end
   end
+
   tests("#change_resource_record_sets_data formats geolocation properly") do
     change_batch = [{
         :action=>"CREATE",
@@ -18,9 +19,11 @@ Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
         :geo_location=>{"CountryCode"=>"US", "SubdivisionCode"=>"AR"},
         }]
 
-    result = Fog::DNS::AWS.change_resource_record_sets_data('zone_id123', change_batch)
+    version = '2013-04-01'
+    result = Fog::DNS::AWS.change_resource_record_sets_data('zone_id123', change_batch, version)
     doc = Nokogiri::XML(result)
 
+    returns("https://route53.amazonaws.com/doc/#{version}/") { doc.namespaces['xmlns'] }
     returns(%w[US AR]) {
       [
         doc.css("GeoLocation CountryCode").text,


### PR DESCRIPTION
This method was broken up into two in 0.7.0, but the big one was changed to a class method. The XML body string, however, still interpolated `@version` to set the XML namespace, and ended up being `https://route53.amazonaws.com/doc//`, which causes AWS to refuse to parse the XML, returning:

    Cannot find the declaration of element 'ChangeResourceRecordSetsRequest'

I was unable to change any RRs until I downgraded to 0.6.0.

I added an `xmlns` check to the test, but it's just a hardcoded string. Maybe an enterprising person could move all the default versions for all AWS services to constants make sure that every `xmlns` is tested somewhere. (Better yet, don't build XML by concatenating strings?) But I'd prefer to just fix this at the moment.