### PR TITLE
Use regex instead of string matching to support redirect correctly when path_style is set to true

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -606,7 +606,7 @@ module Fog
           Fog::Logger.warning("fog: followed redirect to #{host}, connecting to the matching region will be more performant")
           original_region, original_signer = @region, @signer
           @region = @new_region || case new_params[:host]
-          when 's3.amazonaws.com', 's3-external-1.amazonaws.com'
+          when /s3.amazonaws.com/, /s3-external-1.amazonaws.com/
             DEFAULT_REGION
           else
             %r{s3[\.\-]([^\.]*).amazonaws.com}.match(new_params[:host]).captures.first


### PR DESCRIPTION
Signed-off-by: Aakash Shah <ashah@pivotal.io>

Scenario:
- Our S3 bucket is in west
- We set path_style to true when opening a connection. This results in a url such as <bucket>.s3.amazonaws.com versus s3.amazonaws.com/<bucket>
- We have also set 'https://s3.amazonaws.com' for our endpoint
- It appears that when fog creates the connection to S3, S3 responds with a redirect asking it to use <bucket>.s3.amazonaws.com as the endpoint for any subsequent communication.
- As fog parses this redirect request [1], it doesn't appear to respect path_style being true and asserts equality of the endpoint against s3.amazonaws.com to determine the region. Unfortunately, that's not what the endpoint looks like with path_style being true. Fog blows up as it then believes the endpoint to be a non-US Standard endpoint, with the region present in the endpoint, for example: <bucket>.s3-ap-southeast-1.amazonaws.com. [2]
- We do not expect to establish a successful connection to the bucket, but it should not incorrectly parse the response from amazon causing an exception.

[1] https://github.com/fog/fog-aws/blob/3ffd9fa667479fa6f9715e51279be3a20106cede/lib/fog/aws/storage.rb#L591-L621
[2] https://github.com/fog/fog-aws/blob/3ffd9fa667479fa6f9715e51279be3a20106cede/lib/fog/aws/storage.rb#L612

Derek + Aakash