### PR TITLE
Mocked put_bucket no longer clobbers existing bucket

### DIFF
--- a/lib/fog/aws/requests/storage/put_bucket.rb
+++ b/lib/fog/aws/requests/storage/put_bucket.rb
@@ -59,9 +59,9 @@ DATA
           else
             bucket['LocationConstraint'] = nil
           end
-          if !self.data[:buckets][bucket_name] || self.region == 'us-east-1'
+          if !self.data[:buckets][bucket_name]
             self.data[:buckets][bucket_name] = bucket
-          else
+          elsif self.region != 'us-east-1'
             response.status = 409
             raise(Excon::Errors.status_error({:expects => 200}, response))
           end

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -56,6 +56,18 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       end
     end
 
+    tests('put existing bucket - default region - preserves files') do
+      Fog::Storage[:aws].put_bucket(@aws_bucket_name)
+      test_key = Fog::Storage[:aws].directories.get(@aws_bucket_name).files.create(:body => 'test', :key => 'test/key')
+      Fog::Storage[:aws].put_bucket(@aws_bucket_name)
+
+      tests(".body['Contents'].first['Key']").returns('test/key') do
+        Fog::Storage[:aws].get_bucket(@aws_bucket_name).body['Contents'].first['Key']
+      end
+
+      test_key.destroy
+    end
+
     tests("#get_service").formats(@service_format) do
       Fog::Storage[:aws].get_service.body
     end


### PR DESCRIPTION
In the default region (us-east-1), put_bucket will return an existing
bucket, rather than throw a BucketAlreadyOwnedByYou error. Changed the
mock to reflect this behavior.

This fixes https://github.com/fog/fog-aws/issues/172