### PR TITLE
Add GovCloud region name to validation set.

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -224,7 +224,7 @@ module Fog
     end
 
     def self.regions
-      @regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'cn-north-1']
+      @regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'cn-north-1', 'us-gov-west-1']
     end
 
     def self.validate_region!(region, host=nil)


### PR DESCRIPTION
It looks like the GovCloud region was left off  the enumerated set of region names.

It's a bit difficult to parse Amazon's documentation, but we believe 'us-gov-west-1' is the only GovCloud region:
http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html

We discovered this through mitchellh/vagrant-aws, which uses this library to validate Vagrant parameters when building ec2 instances.