### PR TITLE
Yield arguments to Mock#get_object block more similar to Excon

### DIFF
--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -115,10 +115,10 @@ module Fog
                   response.body = body
                 else
                   data = StringIO.new(body)
-                  remaining = data.length
+                  remaining = total_bytes = data.length
                   while remaining > 0
                     chunk = data.read([remaining, Excon::CHUNK_SIZE].min)
-                    block.call(chunk)
+                    block.call(chunk, remaining, total_bytes)
                     remaining -= Excon::CHUNK_SIZE
                   end
                 end


### PR DESCRIPTION
Minor tweak to Mock#get_object to make the arguments yielded to a given block more closely match the arguments that are passed by Excon in the Real case.

Tests seem to be broken on master right now :crying_cat_face: 