### PR TITLE
Disable idempotent option when block is passed to get_object

### DIFF
--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -48,15 +48,17 @@ module Fog
             params[:headers]['If-Unmodified-Since'] = Fog::Time.at(options['If-Unmodified-Since'].to_i).to_date_header
           end
 
+          idempotent = true
           if block_given?
             params[:response_block] = Proc.new
+            idempotent = false
           end
 
           request(params.merge!({
             :expects  => [ 200, 206 ],
             :bucket_name => bucket_name,
             :object_name => object_name,
-            :idempotent => true,
+            :idempotent => idempotent,
             :method   => 'GET',
           }))
         end


### PR DESCRIPTION
The idempotent option can be problematic when calling get_object with a streaming block since Excon automatically retries the entire request from the beginning when something goes wrong, without making it clear that it's doing so. This can result in lots of issues, including data corruption. In order to prevent this, I'd like to propose that we disable the idempotent option whenever a streaming block is provided to get_object.

Original Issue: https://github.com/fog/fog-aws/issues/181