### PR TITLE
mock instance stop and start properly

### DIFF
--- a/lib/fog/aws/requests/compute/describe_instances.rb
+++ b/lib/fog/aws/requests/compute/describe_instances.rb
@@ -199,7 +199,7 @@ module Fog
             when 'rebooting'
               instance['instanceState'] = { 'code' => 16, 'name' => 'running' }
             when 'stopping'
-              instance['instanceState'] = { 'code' => 0, 'name' => 'stopping' }
+              instance['instanceState'] = { 'code' => 0, 'name' => 'stopped' }
               instance['stateReason'] = { 'code' => 0 }
             when 'shutting-down'
               if Time.now - self.data[:deleted_at][instance['instanceId']] >= Fog::Mock.delay * 2

--- a/lib/fog/aws/requests/compute/start_instances.rb
+++ b/lib/fog/aws/requests/compute/start_instances.rb
@@ -41,6 +41,7 @@ module Fog
             response.status = 200
 
             response.body = {
+              'requestId'    => Fog::AWS::Mock.request_id,
               'instancesSet' => instance_set.reduce([]) do |ia, instance|
                                   ia << {'currentState' => { 'code' => 0, 'name' => 'pending' },
                                          'previousState' => instance['instanceState'],

--- a/lib/fog/aws/requests/compute/stop_instances.rb
+++ b/lib/fog/aws/requests/compute/stop_instances.rb
@@ -42,6 +42,7 @@ module Fog
             response.status = 200
 
             response.body = {
+              'requestId'    => Fog::AWS::Mock.request_id,
               'instancesSet' => instance_set.reduce([]) do |ia, instance|
                                   instance['classicLinkSecurityGroups'] = nil
                                   instance['classicLinkVpcId'] = nil

--- a/tests/models/compute/server_tests.rb
+++ b/tests/models/compute/server_tests.rb
@@ -60,6 +60,17 @@ Shindo.tests("Fog::Compute[:aws] | monitor", ['aws']) do
       @instance.associate_public_ip == false
     end
 
+    test('#stop') do
+      @instance.stop
+      @instance.wait_for { state == "stopped" }
+      @instance.state == "stopped"
+    end
+
+    test("#start") do
+      @instance.start
+      @instance.wait_for { ready? }
+      @instance.state == "running"
+    end
   end
 
   @instance.destroy

--- a/tests/requests/compute/instance_tests.rb
+++ b/tests/requests/compute/instance_tests.rb
@@ -81,7 +81,7 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
     'timestamp'    => Time
   }
 
-  @terminate_instances_format = {
+  @instance_state_change_format = {
     'instancesSet'  => [{
       'currentState' => {'code' => Integer, 'name' => String},
       'instanceId'    => String,
@@ -161,6 +161,7 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
       'eventsSet'        => [Fog::Nullable::Hash],
     }]
   }
+
   tests('success') do
 
     @instance_id = nil
@@ -246,7 +247,15 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
       Fog::Compute[:aws].reboot_instances(@instance_id).body
     end
 
-    tests("#terminate_instances('#{@instance_id}')").formats(@terminate_instances_format) do
+    tests("#stop_instances('#{@instance_id}')").formats(@instance_state_change_format) do
+      Fog::Compute[:aws].stop_instances(@instance_id).body
+    end
+
+    tests("#start_instances('#{@instance_id}')").formats(@instance_state_change_format) do
+      Fog::Compute[:aws].start_instances(@instance_id).body
+    end
+
+    tests("#terminate_instances('#{@instance_id}')").formats(@instance_state_change_format) do
       Fog::Compute[:aws].terminate_instances(@instance_id).body
     end
 


### PR DESCRIPTION
* `Server#stop` was returning the wrong state
* `#stop_instances` and `#start_instances` mocks did not include the `requestId`
* tests for all of the above