### PR TITLE
Treat storage-class header case-agnostically

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -20,7 +20,7 @@ module Fog
         attribute :last_modified,       :aliases => ['Last-Modified', 'LastModified']
         attribute :metadata
         attribute :owner,               :aliases => 'Owner'
-        attribute :storage_class,       :aliases => ['x-amz-storage-class', 'StorageClass']
+        attribute :storage_class,       :aliases => ['x-amz-storage-class', 'X-Amz-Storage-Class', 'StorageClass']
         attribute :encryption,          :aliases => 'x-amz-server-side-encryption'
         attribute :encryption_key,      :aliases => 'x-amz-server-side-encryption-customer-key'
         attribute :version,             :aliases => 'x-amz-version-id'


### PR DESCRIPTION
The HTTP spec specifies that headers are case-insensitive, but fog
does not treat them that way. In general, this is not a problem because
excon handles this, but when using VCR, headers are recorded as camel-case,
which are then not recognized by fog-aws.