### PR TITLE
Allow region to be set for STS

### DIFF
--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -7,7 +7,7 @@ module Fog
       class ValidationError < Fog::AWS::STS::Error; end
       class AwsAccessKeysMissing < Fog::AWS::STS::Error; end
 
-      recognizes :aws_access_key_id, :aws_secret_access_key, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :aws_access_key_id, :aws_secret_access_key, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
 
       request_path 'fog/aws/requests/sts'
       request :get_federation_token
@@ -79,7 +79,8 @@ module Fog
           @instrumentor_name  = options[:instrumentor_name] || 'fog.aws.sts'
           @connection_options     = options[:connection_options] || {}
 
-          @host       = options[:host]        || 'sts.amazonaws.com'
+          @region     = options[:region]      || 'us-east-1'
+          @host       = options[:host]        || "sts.#{@region}.amazonaws.com"
           @path       = options[:path]        || '/'
           @persistent = options[:persistent]  || false
           @port       = options[:port]        || 443
@@ -100,7 +101,7 @@ module Fog
           @aws_credentials_expire_at = options[:aws_credentials_expire_at]
 
           if (@aws_access_key_id && @aws_secret_access_key)
-            @signer = Fog::AWS::SignatureV4.new(@aws_access_key_id, @aws_secret_access_key, 'us-east-1', 'sts')
+            @signer = Fog::AWS::SignatureV4.new(@aws_access_key_id, @aws_secret_access_key, @region, 'sts')
           end
         end
 

--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -74,12 +74,12 @@ module Fog
         def initialize(options={})
 
           @use_iam_profile = options[:use_iam_profile]
+          @region     = options[:region]      || 'us-east-1'
           setup_credentials(options)
           @instrumentor       = options[:instrumentor]
           @instrumentor_name  = options[:instrumentor_name] || 'fog.aws.sts'
           @connection_options     = options[:connection_options] || {}
 
-          @region     = options[:region]      || 'us-east-1'
           @host       = options[:host]        || "sts.#{@region}.amazonaws.com"
           @path       = options[:path]        || '/'
           @persistent = options[:persistent]  || false


### PR DESCRIPTION
STS is now available in all regions. (although somewhat oddly you have to manually enable each region other than us-east-1 from the AWS console - see https://blogs.aws.amazon.com/security/post/Tx3CYWU11LY2GLB/AWS-Security-Token-Service-Is-Now-Available-in-Every-AWS-Region )