### PR TITLE
Cache cluster security group parser

### DIFF
--- a/lib/fog/aws/models/elasticache/cluster.rb
+++ b/lib/fog/aws/models/elasticache/cluster.rb
@@ -18,7 +18,8 @@ module Fog
         attribute :parameter_group, :aliases => 'CacheParameterGroup'
         attribute :pending_values, :aliases => 'PendingModifiedValues'
         attribute :create_time, :aliases => 'CacheClusterCreateTime', :type => :timestamp
-        attribute :security_groups, :aliases => 'CacheSecurityGroups', :type => :array
+        attribute :cache_security_groups, :aliases => 'CacheSecurityGroups', :type => :array
+        attribute :security_groups, :aliases => 'SecurityGroups', :type => :array
         attribute :notification_config, :aliases => 'NotificationConfiguration'
         attribute :cache_subnet_group_name, :aliases => 'CacheSubnetGroupName'
         attribute :vpc_security_groups, :aliases => 'VpcSecurityGroups', :type => :array

--- a/lib/fog/aws/requests/elasticache/create_cache_cluster.rb
+++ b/lib/fog/aws/requests/elasticache/create_cache_cluster.rb
@@ -72,6 +72,7 @@ module Fog
             'CacheClusterStatus'  => 'available',
             'CacheNodes'          => create_cache_nodes(id.strip, options[:num_nodes]),
             'CacheSecurityGroups' => [],
+            'SecurityGroups'  => [],
             'CacheParameterGroup' => { 'CacheParameterGroupName' =>
                 options[:parameter_group_name] || 'default.memcached1.4' },
             'CacheSubnetGroupName' => options[:cache_subnet_group_name],


### PR DESCRIPTION
Not sure if this is a bug or just Fog not keeping pace with the AWS API but it looks like ElastiCache security groups took on a new format and are now available under a key called `SecurityGroups`. This PR adds parsing for that key without dropping parsing for the old one. Let me know what you think.

Note that I didn't add any unit tests because there did not appear to be a test framework already set up for ElastiCache in Fog and I don't really have the cycles (or the knowledge, really) to create one just to test this one fix.