### PR TITLE
filters on tags can pass an array

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -415,7 +415,7 @@ module Fog
             tag_filters[key.gsub('tag:', '')] = filters.delete(key) if /^tag:/ =~ key
           end
           for tag_key, tag_value in tag_filters
-            resources = resources.select{|r| tag_value == tag_set_fetcher[r][tag_key]}
+            resources = resources.select{|r| [tag_value].flatten.include? tag_set_fetcher[r][tag_key]}
           end
 
           resources

--- a/tests/requests/compute/instance_tests.rb
+++ b/tests/requests/compute/instance_tests.rb
@@ -218,6 +218,39 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
 
     another_server.destroy
 
+    tests("#run_instances_with_tags").formats(@describe_instances_format) do
+
+      svr1 = Fog::Compute[:aws].servers.create(
+          :availability_zone => 'eu-west-1a',
+          :tags => {
+              "Name"  => "test::test::test",
+              "Stack" => "test",
+              "Stage" => "test",
+              "App"   => "test1",
+          },
+          :image_id => 'ami-3d7e2e54',
+          :flavor_id =>  't1.micro',
+      )
+      svr2 = Fog::Compute[:aws].servers.create(
+          :availability_zone => 'eu-west-1b',
+          :tags => {
+              "Name"  => "test::test::dev",
+              "Stack" => "test",
+              "Stage" => "test",
+              "App"   => "test2",
+          },
+          :image_id => 'ami-3d7e2e54',
+          :flavor_id =>  't1.micro',
+      )
+
+      filters = {'tag:App' => ['test1', 'test2']}
+      body = Fog::Compute[:aws].describe_instances('tag:App' => ['test1', 'test2']).body
+      tests("returns 2 hosts").returns(2) { body['reservationSet'].size }
+      svr1.destroy
+      svr2.destroy
+      body
+    end
+
     tests("#get_console_output('#{@instance_id}')").formats(@get_console_output_format) do
       Fog::Compute[:aws].get_console_output(@instance_id).body
     end


### PR DESCRIPTION
this comparison works fine where there is just a string or single tag,
where there is an array of tags this comparison breaks fails.

So instead we must cast to an array and then do a comparison by an
inclusion of a a value in an array