### PR TITLE
Add mime-types to test section in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gemspec
 
 group :test, :default do
   gem 'pry-nav'
+  gem 'mime-types', '~> 2.6', '>= 2.6.2'
 end
 gem "codeclimate-test-reporter", group: :test, require: nil


### PR DESCRIPTION
The mime-types gem is needed to run the tests. 