### PR TITLE
Reset 'finished' when rewinding S3Streamer

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -646,6 +646,7 @@ module Fog
           #we must also reset the signature
           def rewind
             self.signature = initial_signature
+            self.finished = false
             body.rewind
           end
 


### PR DESCRIPTION
I've found that when idempotent PUT requests are retried, the bodies of the requests are empty because the `self.finished` attribute of the `S3Streamer` is evaluating to `true`. If the attribute to reset to `false` when `#rewind` is called, the body of the request is sent on retries.