### PR TITLE
Update dynamodb to use the latest API version

### DIFF
--- a/lib/fog/aws/requests/dynamodb/batch_get_item.rb
+++ b/lib/fog/aws/requests/dynamodb/batch_get_item.rb
@@ -8,22 +8,19 @@ module Fog
         # * 'request_items'<~Hash>:
         #   * 'table_name'<~Hash>:
         #     * 'Keys'<~Array>: array of keys
-        #       * 'HashKeyElement'<~Hash>: info for primary key
-        #         * 'AttributeType'<~String> - type of attribute
-        #         * 'AttributeName'<~String> - name of attribute
-        #       * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #         * 'AttributeType'<~String> - type of attribute
-        #         * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributesToGet'<~Array> - optional attributes to return, defaults to all
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'Responses'<~Hash>:
-        #       * 'table_name'<~Hash>:
-        #         * 'Items'<~Array> - Matching items
-        #         * 'ConsumedCapacityUnits'<~Float> - Capacity units used in read
+        #       * 'table_name'<~Array> - array of all elements
         #     * 'UnprocessedKeys':<~Hash> - tables and keys in excess of per request limit, pass this to subsequent batch get for pseudo-pagination
+        #     * 'ConsumedCapacity':<~Hash>:
+        #       * 'TableName'<~String> - the name of the table
+        #       * 'CapacityUnits'<~Float> - Capacity units used in read
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
+        #
         def batch_get_item(request_items)
           body = {
             'RequestItems' => request_items
@@ -31,7 +28,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.BatchGetItem'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.BatchGetItem'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/batch_write_item.rb
+++ b/lib/fog/aws/requests/dynamodb/batch_write_item.rb
@@ -7,16 +7,18 @@ module Fog
           batch_write_item(request_items)
         end
 
-        #request_items has form:
-        #{"table_name"=>
+        # request_items has form:
+        #
+        # {"table_name"=>
         #  [{"PutRequest"=>
         #    {"Item"=>
-        #      {"hash_key"=>{"N"=>"99"},
-        #       "range_key"=>{"N"=>"99"},
-        #       "attribute"=>{"S"=>"hi"}
-        #       }}}, ... ]}
-        # For more information:
-        # http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_BatchWriteItems.html
+        #       {"hi" => {"N" => 99}}
+        #    }
+        #  }]
+        # }
+        #
+        # See DynamoDB Documentation: http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_BatchWriteItems.html
+        #
         def batch_write_item(request_items)
           body = {
             'RequestItems' => request_items
@@ -24,7 +26,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.BatchWriteItem'}
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.BatchWriteItem'}
           )
         end
       end

--- a/lib/fog/aws/requests/dynamodb/create_table.rb
+++ b/lib/fog/aws/requests/dynamodb/create_table.rb
@@ -6,14 +6,10 @@ module Fog
         #
         # ==== Parameters
         # * 'table_name'<~String> - name of table to create
-        # * 'key_schema'<~Hash>:
-        #   * 'HashKeyElement'<~Hash>: info for primary key
+        # * 'key_schema'<~Array>:
         #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        #   * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        # * 'provisioned_throughput'<~Hash>:
+        #     * 'KeyType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
+        # * 'ProvisionedThroughput'<~Hash>:
         #   * 'ReadCapacityUnits'<~Integer> - read capacity for table, in 5..10000
         #   * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #
@@ -22,18 +18,17 @@ module Fog
         #   * body<~Hash>:
         #     * 'TableDescription'<~Hash>
         #       * 'CreationDateTime'<~Float> - Unix epoch time of table creation
-        #       * 'KeySchema'<~Hash> - schema for table
-        #         * 'HashKeyElement'<~Hash>: info for primary key
+        #       * 'KeySchema'<~Array> - schema for table
         #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        #         * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
+        #           * 'KeyType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
         #       * 'ProvisionedThroughput'<~Hash>:
         #         * 'ReadCapacityUnits'<~Integer> - read capacity for table, in 5..10000
         #         * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #       * 'TableName'<~String> - name of table
         #       * 'TableStatus'<~String> - status of table
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html
+        #
         def create_table(table_name, key_schema, provisioned_throughput)
           body = {
             'KeySchema'             => key_schema,
@@ -43,7 +38,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.CreateTable'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.CreateTable'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/delete_item.rb
+++ b/lib/fog/aws/requests/dynamodb/delete_item.rb
@@ -6,25 +6,15 @@ module Fog
         #
         # ==== Parameters
         # * 'table_name'<~String> - name of table for item
-        # * 'key'<~Hash>:
-        #   * 'HashKeyElement'<~Hash>: info for primary key
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute
-        #   * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute
-        # * 'options'<~Hash>:
-        #   * 'Expected'<~Hash>: data to check against
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'Value'<~Hash> - a value to check for the value of
-        #     or
-        #     * 'Exists'<~Boolean> - set as false to only allow update if attribute doesn't exist
-        #   * 'ReturnValues'<~String> - data to return in %w{ALL_NEW ALL_OLD NONE UPDATED_NEW UPDATED_OLD}, defaults to NONE
+        # * 'key'<~Hash> - hash of attributes
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     varies based on ReturnValues param, see: http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_UpdateItem.html
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html
+        #
         def delete_item(table_name, key, options = {})
           body = {
             'Key'               => key,
@@ -33,7 +23,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.DeleteItem'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.DeleteItem'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/delete_table.rb
+++ b/lib/fog/aws/requests/dynamodb/delete_table.rb
@@ -11,18 +11,14 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'TableDescription'<~Hash>
-        #       * 'KeySchema'<~Hash> - schema for table
-        #         * 'HashKeyElement'<~Hash>: info for primary key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        #         * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
         #       * 'ProvisionedThroughput'<~Hash>:
         #         * 'ReadCapacityUnits'<~Integer> - read capacity for table, in 5..10000
         #         * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #       * 'TableName'<~String> - name of table
         #       * 'TableStatus'<~String> - status of table
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteTable.html
+        #
         def delete_table(table_name)
           body = {
             'TableName' => table_name
@@ -30,7 +26,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.DeleteTable'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.DeleteTable'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/describe_table.rb
+++ b/lib/fog/aws/requests/dynamodb/describe_table.rb
@@ -12,19 +12,18 @@ module Fog
         #   * body<~Hash>:
         #     * 'Table'<~Hash>
         #       * 'CreationDateTime'<~Float> - Unix epoch time of table creation
-        #       * 'KeySchema'<~Hash> - schema for table
-        #         * 'HashKeyElement'<~Hash>: info for primary key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        #         * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
+        #       * 'KeySchema'<~Array> - schema for table
+        #         * 'AttributeName'<~String> - name of attribute
+        #         * 'KeyType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
         #       * 'ProvisionedThroughput'<~Hash>:
         #         * 'ReadCapacityUnits'<~Integer> - read capacity for table, in 5..10000
         #         * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #       * 'TableName'<~String> - name of table
         #       * 'TableSizeBytes'<~Integer> - size of table in bytes
         #       * 'TableStatus'<~String> - status of table
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html
+        #
         def describe_table(table_name)
           body = {
             'TableName' => table_name
@@ -32,7 +31,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.DescribeTable'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.DescribeTable'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/get_item.rb
+++ b/lib/fog/aws/requests/dynamodb/get_item.rb
@@ -7,12 +7,11 @@ module Fog
         # ==== Parameters
         # * 'table_name'<~String> - name of table for item
         # * 'key'<~Hash>:
-        #   * 'HashKeyElement'<~Hash>: info for primary key
-        #     * 'AttributeType'<~String> - type of attribute
-        #     * 'AttributeName'<~String> - name of attribute
-        #   * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #     * 'AttributeType'<~String> - type of attribute
-        #     * 'AttributeName'<~String> - name of attribute
+        #     {
+        #       "ForumName": {
+        #         "S": "Amazon DynamoDB"
+        #       }
+        #     }
         # * 'options'<~Hash>:
         #   * 'AttributesToGet'<~Array>: list of array names to return, defaults to returning all
         #   * 'ConsistentRead'<~Boolean>: whether to wait for updates, defaults to false
@@ -23,6 +22,9 @@ module Fog
         #     * 'ConsumedCapacityUnits'<~Float> - Capacity units used in read
         #     * 'Item':<~Hash>:
         #       * 'AttributeName'<~Hash>: in form of {"type":value}
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html
+        #
         def get_item(table_name, key, options = {})
           body = {
             'Key'               => key,
@@ -31,7 +33,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.GetItem'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.GetItem'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/list_tables.rb
+++ b/lib/fog/aws/requests/dynamodb/list_tables.rb
@@ -14,10 +14,13 @@ module Fog
         #   * body<~Hash>:
         #     * 'LastEvaluatedTableName'<~String> - last table name, for pagination
         #     * 'TableNames'<~Array> - table names
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
+        #
         def list_tables(options = {})
           request(
             :body       => Fog::JSON.encode(options),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.ListTables'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.ListTables'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/put_item.rb
+++ b/lib/fog/aws/requests/dynamodb/put_item.rb
@@ -7,21 +7,17 @@ module Fog
         # ==== Parameters
         # * 'table_name'<~String> - name of table for item
         # * 'item'<~Hash>: data to update, must include primary key
-        #   * 'AttributeName'<~String> - Attribute to update
-        #     * 'Value'<~Hash> - formated as {type => value}
-        #     * 'Action'<~String> - action to take if expects matches, in %w{ADD DELETE PUT}, defaults to PUT
-        # * 'options'<~Hash>:
-        #   * 'Expected'<~Hash>: data to check against
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'Value'<~Hash> - a value to check for the value of
-        #     or
-        #     * 'Exists'<~Boolean> - set as false to only allow update if attribute doesn't exist
-        #   * 'ReturnValues'<~String> - data to return in %w{ALL_NEW ALL_OLD NONE UPDATED_NEW UPDATED_OLD}, defaults to NONE
+        #   {
+        #     "LastPostDateTime": {"S": "201303190422"}
+        #   }
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     varies based on ReturnValues param, see: http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_UpdateItem.html
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+        #
         def put_item(table_name, item, options = {})
           body = {
             'Item'      => item,

--- a/lib/fog/aws/requests/dynamodb/query.rb
+++ b/lib/fog/aws/requests/dynamodb/query.rb
@@ -6,15 +6,13 @@ module Fog
         #
         # ==== Parameters
         # * 'table_name'<~String> - name of table to query
-        # * 'hash_key'<~Hash> - hash key to query
         # * options<~Hash>:
         #   * 'AttributesToGet'<~Array> - Array of attributes to get for each item, defaults to all
         #   * 'ConsistentRead'<~Boolean> - Whether to wait for consistency, defaults to false
         #   * 'Count'<~Boolean> - If true, returns only a count of such items rather than items themselves, defaults to false
         #   * 'Limit'<~Integer> - limit of total items to return
-        #   * 'RangeKeyCondition'<~Hash>: value to compare against range key
-        #     * 'AttributeValueList'<~Hash>: one or more values to compare against
-        #     * 'ComparisonOperator'<~String>: comparison operator to use with attribute value list, in %w{BETWEEN BEGINS_WITH EQ LE LT GE GT}
+        #   * 'KeyConditionExpression'<~String> - the condition elements need to match
+        #   * 'ExpressionAttributeValues'<~Hash> - values to be used in the key condition expression
         #   * 'ScanIndexForward'<~Boolean>: Whether to scan from start or end of index, defaults to start
         #   * 'ExclusiveStartKey'<~Hash>: Key to start listing from, can be taken from LastEvaluatedKey in response
         #
@@ -25,15 +23,17 @@ module Fog
         #     * 'Count'<~Integer> - number of items in response
         #     * 'Items'<~Array> - array of items returned
         #     * 'LastEvaluatedKey'<~Hash> - last key scanned, can be passed to ExclusiveStartKey for pagination
-        def query(table_name, hash_key, options = {})
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
+        #
+        def query(table_name, options = {})
           body = {
-            'TableName'     => table_name,
-            'HashKeyValue'  => hash_key
+            'TableName'     => table_name
           }.merge(options)
 
           request(
             :body     => Fog::JSON.encode(body),
-            :headers  => {'x-amz-target' => 'DynamoDB_20111205.Query'}
+            :headers  => {'x-amz-target' => 'DynamoDB_20120810.Query'}
           )
         end
       end

--- a/lib/fog/aws/requests/dynamodb/query.rb
+++ b/lib/fog/aws/requests/dynamodb/query.rb
@@ -26,14 +26,22 @@ module Fog
         #
         # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
         #
-        def query(table_name, options = {})
+        def query(table_name, options = {}, hash_key_deprecated = nil)
+          if hash_key_deprecated || (options.keys.length == 1 && [:S, :N, :B].include?(options.keys.first.to_sym))
+            Fog::Logger.deprecation("The `20111205` API version is deprecated. You need to use `KeyConditionExpression` instead of `HashKey`.")
+            apiVersion = '20111205'
+            hash_key = options
+            options = hash_key_deprecated
+          end
+
           body = {
-            'TableName'     => table_name
+            'TableName'     => table_name,
+            'HashKeyValue'  => hash_key
           }.merge(options)
 
           request(
             :body     => Fog::JSON.encode(body),
-            :headers  => {'x-amz-target' => 'DynamoDB_20120810.Query'}
+            :headers  => {'x-amz-target' => "DynamoDB_#{apiVersion || '20120810'}.Query"}
           )
         end
       end

--- a/lib/fog/aws/requests/dynamodb/scan.rb
+++ b/lib/fog/aws/requests/dynamodb/scan.rb
@@ -11,11 +11,8 @@ module Fog
         #   * 'ConsistentRead'<~Boolean> - Whether to wait for consistency, defaults to false
         #   * 'Count'<~Boolean> - If true, returns only a count of such items rather than items themselves, defaults to false
         #   * 'Limit'<~Integer> - limit of total items to return
-        #   * 'ScanFilter'<~Hash>: value to compare against
-        #     * attribute_name<~Hash>:
-        #       * 'AttributeValueList'<~Array>: one or more values to compare against
-        #         * 'AttributeValue'<~Hash> - formated as {type => value}
-        #       * 'ComparisonOperator'<~String>: comparison operator to use with attribute value list, in %w{BETWEEN BEGINS_WITH EQ LE LT GE GT}
+        #   * 'KeyConditionExpression'<~String> - the condition elements need to match
+        #   * 'ExpressionAttributeValues'<~Hash> - values to be used in the key condition expression
         #   * 'ScanIndexForward'<~Boolean>: Whether to scan from start or end of index, defaults to start
         #   * 'ExclusiveStartKey'<~Hash>: Key to start listing from, can be taken from LastEvaluatedKey in response
         #
@@ -27,6 +24,9 @@ module Fog
         #     * 'Items'<~Array> - array of items returned
         #     * 'LastEvaluatedKey'<~Hash> - last key scanned, can be passed to ExclusiveStartKey for pagination
         #     * 'ScannedCount'<~Integer> - number of items scanned before applying filters
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
+        #
         def scan(table_name, options = {})
           body = {
             'TableName'     => table_name
@@ -34,7 +34,7 @@ module Fog
 
           request(
             :body     => Fog::JSON.encode(body),
-            :headers  => {'x-amz-target' => 'DynamoDB_20111205.Scan'},
+            :headers  => {'x-amz-target' => 'DynamoDB_20120810.Scan'},
             :idempotent => true
           )
         end

--- a/lib/fog/aws/requests/dynamodb/update_item.rb
+++ b/lib/fog/aws/requests/dynamodb/update_item.rb
@@ -2,6 +2,7 @@ module Fog
   module AWS
     class DynamoDB
       class Real
+        class DeprecatedAttributeUpdates < Exception; end
         # Update DynamoDB item
         #
         # ==== Parameters
@@ -24,10 +25,17 @@ module Fog
         #
         # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
         #
-        def update_item(table_name, key, options = {})
+        def update_item(table_name, key, options = {}, deprecated_attribute_updates = nil)
+          if deprecated_attribute_updates
+            raise DeprecatedAttributeUpdates, "The `20111205` DynamoDB API is deprecated. You need to use `ExpressionAttributeValues` instead of `AttributeUpdates`."
+            attribute_updates = options
+            options = deprecated_attribute_updates
+          end
+
           body = {
             'Key'               => key,
-            'TableName'         => table_name
+            'TableName'         => table_name,
+            'AttributeUpdates'  => attribute_updates,
           }.merge(options)
 
           request(

--- a/lib/fog/aws/requests/dynamodb/update_item.rb
+++ b/lib/fog/aws/requests/dynamodb/update_item.rb
@@ -6,39 +6,33 @@ module Fog
         #
         # ==== Parameters
         # * 'table_name'<~String> - name of table for item
-        # * 'key'<~Hash>:
-        #   * 'HashKeyElement'<~Hash>: info for primary key
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute
-        #   * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'AttributeType'<~String> - type of attribute
-        # * 'attribute_updates'<~Hash>:
-        #   * 'AttributeName'<~String> - Attribute to update
-        #     * 'Value'<~Hash> - formated as {type => value}
-        #     * 'Action'<~String> - action to take if expects matches, in %w{ADD DELETE PUT}, defaults to PUT
+        # * 'key'<~Hash> - list of elements to be updated and their value
+        #   {
+        #     "ForumName": {"S": "Amazon DynamoDB"},
+        #     "Subject": {"S": "Maximum number of items?"}
+        #   }
+        #
         # * 'options'<~Hash>:
-        #   * 'Expected'<~Hash>: data to check against
-        #     * 'AttributeName'<~String> - name of attribute
-        #     * 'Value'<~Hash> - a value to check for the value of
-        #     or
-        #     * 'Exists'<~Boolean> - set as false to only allow update if attribute doesn't exist
+        #   * 'KeyConditionExpression'<~String> - the condition elements need to match
+        #   * 'ExpressionAttributeValues'<~Hash> - values to be used in the key condition expression
         #   * 'ReturnValues'<~String> - data to return in %w{ALL_NEW ALL_OLD NONE UPDATED_NEW UPDATED_OLD}, defaults to NONE
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     varies based on ReturnValues param, see: http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_UpdateItem.html
-        def update_item(table_name, key, attribute_updates, options = {})
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
+        #
+        def update_item(table_name, key, options = {})
           body = {
-            'AttributeUpdates'  => attribute_updates,
             'Key'               => key,
             'TableName'         => table_name
           }.merge(options)
 
           request(
             :body     => Fog::JSON.encode(body),
-            :headers  => {'x-amz-target' => 'DynamoDB_20111205.UpdateItem'}
+            :headers  => {'x-amz-target' => 'DynamoDB_20120810.UpdateItem'}
           )
         end
       end

--- a/lib/fog/aws/requests/dynamodb/update_table.rb
+++ b/lib/fog/aws/requests/dynamodb/update_table.rb
@@ -14,18 +14,17 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'Table'<~Hash>
-        #       * 'KeySchema'<~Hash> - schema for table
-        #         * 'HashKeyElement'<~Hash>: info for primary key
+        #       * 'KeySchema'<~Array> - schema for table
         #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
-        #         * 'RangeKeyElement'<~Hash>: optional, info for range key
-        #           * 'AttributeName'<~String> - name of attribute
-        #           * 'AttributeType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
+        #           * 'KeyType'<~String> - type of attribute, in %w{N NS S SS} for number, number set, string, string set
         #       * 'ProvisionedThroughput'<~Hash>:
         #         * 'ReadCapacityUnits'<~Integer> - read capacity for table, in 5..10000
         #         * 'WriteCapacityUnits'<~Integer> - write capacity for table, in 5..10000
         #       * 'TableName'<~String> - name of table
         #       * 'TableStatus'<~String> - status of table
+        #
+        # See DynamoDB Documentation: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html
+        #
         def update_table(table_name, provisioned_throughput)
           body = {
             'ProvisionedThroughput' => provisioned_throughput,
@@ -34,7 +33,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.UpdateTable'},
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.UpdateTable'},
             :idempotent => true
           )
         end

--- a/tests/requests/dynamodb/item_tests.rb
+++ b/tests/requests/dynamodb/item_tests.rb
@@ -91,10 +91,10 @@ Shindo.tests('Fog::AWS[:dynamodb] | item requests', ['aws']) do
       'LastEvaluatedKey'      => NilClass
     }
 
-    tests("#query('#{@table_name}', {'S' => 'key'}").formats(@query_format) do
+    tests("#query('#{@table_name}')").formats(@query_format) do
       pending if Fog.mocking?
       pending # requires a table with range key
-      Fog::AWS[:dynamodb].query(@table_name, {'S' => 'key'}).body
+      Fog::AWS[:dynamodb].query(@table_name).body
     end
 
     @scan_format = @query_format.merge('ScannedCount' => Integer)


### PR DESCRIPTION
The `20111205` API version is deprecated, and doesn't provide many of the features the latest version offers, such as the [conditional parameters](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html).