### PR TITLE
Support NoncurrentVersion[Expiration,Transition] for s3 lifecycle.

### DIFF
--- a/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
@@ -55,7 +55,7 @@ module Fog
                 @transition['StorageClass'] = value
               when 'Date'
                 @transition[name] = value
-              when 'NoncurrentDays'
+              when 'Days'
                 @transition[name] = value.to_i
               when 'Transition'
                 @rule['Transition'] = @transition
@@ -68,7 +68,7 @@ module Fog
                 @version_transition['StorageClass'] = value
               when 'Date'
                 @version_transition[name] = value
-              when 'Days'
+              when 'NoncurrentDays'
                 @version_transition[name] = value.to_i
               when 'NoncurrentVersionTransition'
                 @rule['NoncurrentVersionTransition'] = @transition

--- a/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
@@ -5,7 +5,9 @@ module Fog
         class GetBucketLifecycle < Fog::Parsers::Base
           def reset
             @expiration = {}
+            @version_expiration = {}
             @transition = {}
+            @version_transition = {}
             @rule = {}
             @response = { 'Rules' => [] }
           end
@@ -17,6 +19,10 @@ module Fog
               @in_expiration = true
             when 'Transition'
               @in_transition = true
+            when 'NoncurrentVersionExpiration'
+              @in_version_expiration = true
+            when 'NoncurrentVersionTransition'
+              @in_version_transition = true
             end
           end
 
@@ -32,18 +38,42 @@ module Fog
                 @in_expiration = false
                 @expiration = {}
               end
+            elsif @in_version_expiration
+              case name
+              when 'NoncurrentDays'
+                @version_expiration[name] = value.to_i
+              when 'Date'
+                @version_expiration[name] = value
+              when 'NoncurrentVersionExpiration'
+                @rule['NoncurrentVersionExpiration'] = @version_expiration
+                @in_version_expiration = false
+                @version_expiration = {}
+              end
             elsif @in_transition
               case name
               when 'StorageClass',
                 @transition['StorageClass'] = value
               when 'Date'
                 @transition[name] = value
-              when 'Days'
+              when 'NoncurrentDays'
                 @transition[name] = value.to_i
               when 'Transition'
                 @rule['Transition'] = @transition
                 @in_transition = false
                 @transition = {}
+              end
+            elsif @in_version_transition
+              case name
+              when 'StorageClass',
+                @version_transition['StorageClass'] = value
+              when 'Date'
+                @version_transition[name] = value
+              when 'Days'
+                @version_transition[name] = value.to_i
+              when 'NoncurrentVersionTransition'
+                @rule['NoncurrentVersionTransition'] = @transition
+                @in_version_transition = false
+                @version_transition = {}
               end
             else
               case name

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -33,7 +33,7 @@ module Fog
                   ID rule['ID']
                   Prefix rule['Prefix']
                   Status rule['Enabled'] ? 'Enabled' : 'Disabled'
-                  unless (rule['Expiration'] or rule['Transition'])
+                  unless (rule['Expiration'] or rule['Transition'] or rule['NonCurrentVersionExpiration'] or rule['NonCurrentVersionTransition'])
                     Expiration { Days rule['Days'] }
                   else
                     if rule['Expiration']
@@ -44,14 +44,14 @@ module Fog
                       end
                     end
                     if rule['NonCurrentVersionExpiration']
-                      if rule['NonCurrentVersoinExpiration']['Days']
-                        NonCurrentVersoinExpiration { Days rule['NonCurrentVersoinExpiration']['Days'] }
-                      elsif rule['NonCurrentVersoinExpiration']['Date']
+                      if rule['NonCurrentVersionExpiration']['Days']
+                        NonCurrentVersoinExpiration { Days rule['NonCurrentVersionExpiration']['Days'] }
+                      elsif rule['NonCurrentVersionExpiration']['Date']
                         NonCurrentVersoinExpiration {
-                          if Date rule['NonCurrentVersoinExpiration']['Date'].is_a?(Time)
-                            rule['NonCurrentVersoinExpiration']['Date'].utc.iso8601
+                          if Date rule['NonCurrentVersionExpiration']['Date'].is_a?(Time)
+                            rule['NonCurrentVersionExpiration']['Date'].utc.iso8601
                           else
-                            Time.parse(rule['NonCurrentVersoinExpiration']['Date']).utc.iso8601
+                            Time.parse(rule['NonCurrentVersionExpiration']['Date']).utc.iso8601
                           end
                         }
                       end

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -10,13 +10,13 @@ module Fog
         #     * ID [String] Unique identifier for the rule
         #     * Prefix [String] Prefix identifying one or more objects to which the rule applies
         #     * Enabled [Boolean] if rule is currently being applied
-        #     * [NonCurrentVersion]Expiration [Hash] Container for the object expiration rule.
-        #       * Days [Integer] lifetime, in days, of the objects that are subject to the rule
+        #     * [NoncurrentVersion]Expiration [Hash] Container for the object expiration rule.
+        #       * [Noncurrent]Days [Integer] lifetime, in days, of the objects that are subject to the rule
         #       * Date [Date] Indicates when the specific rule take effect.
         #         The date value must conform to the ISO 8601 format. The time is always midnight UTC.
-        #     * [NonCurrentVersion]Transition [Hash] Container for the transition rule that describes when objects transition
+        #     * [NoncurrentVersion]Transition [Hash] Container for the transition rule that describes when objects transition
         #       to the Glacier storage class
-        #       * Days [Integer] lifetime, in days, of the objects that are subject to the rule
+        #       * [Noncurrent]Days [Integer] lifetime, in days, of the objects that are subject to the rule
         #       * Date [Date] Indicates when the specific rule take effect.
         #         The date value must conform to the ISO 8601 format. The time is always midnight UTC.
         #       * StorageClass [String] Indicates the Amazon S3 storage class to which you want the object
@@ -33,7 +33,7 @@ module Fog
                   ID rule['ID']
                   Prefix rule['Prefix']
                   Status rule['Enabled'] ? 'Enabled' : 'Disabled'
-                  unless (rule['Expiration'] or rule['Transition'] or rule['NonCurrentVersionExpiration'] or rule['NonCurrentVersionTransition'])
+                  unless (rule['Expiration'] or rule['Transition'] or rule['NoncurrentVersionExpiration'] or rule['NoncurrentVersionTransition'])
                     Expiration { Days rule['Days'] }
                   else
                     if rule['Expiration']
@@ -43,15 +43,15 @@ module Fog
                         Expiration { Date rule['Expiration']['Date'].is_a?(Time) ? rule['Expiration']['Date'].utc.iso8601 : Time.parse(rule['Expiration']['Date']).utc.iso8601 }
                       end
                     end
-                    if rule['NonCurrentVersionExpiration']
-                      if rule['NonCurrentVersionExpiration']['Days']
-                        NonCurrentVersoinExpiration { Days rule['NonCurrentVersionExpiration']['Days'] }
-                      elsif rule['NonCurrentVersionExpiration']['Date']
-                        NonCurrentVersoinExpiration {
-                          if Date rule['NonCurrentVersionExpiration']['Date'].is_a?(Time)
-                            rule['NonCurrentVersionExpiration']['Date'].utc.iso8601
+                    if rule['NoncurrentVersionExpiration']
+                      if rule['NoncurrentVersionExpiration']['NoncurrentDays']
+                        NoncurrentVersionExpiration { NoncurrentDays rule['NoncurrentVersionExpiration']['NoncurrentDays'] }
+                      elsif rule['NoncurrentVersionExpiration']['Date']
+                        NoncurrentVersoinExpiration {
+                          if Date rule['NoncurrentVersionExpiration']['Date'].is_a?(Time)
+                            rule['NoncurrentVersionExpiration']['Date'].utc.iso8601
                           else
-                            Time.parse(rule['NonCurrentVersionExpiration']['Date']).utc.iso8601
+                            Time.parse(rule['NoncurrentVersionExpiration']['Date']).utc.iso8601
                           end
                         }
                       end
@@ -66,14 +66,14 @@ module Fog
                         StorageClass rule['Transition']['StorageClass'].nil? ? 'GLACIER' : rule['Transition']['StorageClass']
                       }
                     end
-                    if rule['NonCurrentVersionTransition']
-                      NonCurrentVersionTransition {
-                        if rule['NonCurrentVersionTransition']['Days']
-                          Days rule['NonCurrentVersionTransition']['Days']
-                        elsif rule['NonCurrentVersionTransition']['Date']
-                          Date rule['NonCurrentVersionTransition']['Date'].is_a?(Time) ? time.utc.iso8601 : Time.parse(time).utc.iso8601
+                    if rule['NoncurrentVersionTransition']
+                      NoncurrentVersionTransition {
+                        if rule['NoncurrentVersionTransition']['NoncurrentDays']
+                          NoncurrentDays rule['NoncurrentVersionTransition']['NoncurrentDays']
+                        elsif rule['NoncurrentVersionTransition']['Date']
+                          Date rule['NoncurrentVersionTransition']['Date'].is_a?(Time) ? time.utc.iso8601 : Time.parse(time).utc.iso8601
                         end
-                        StorageClass rule['NonCurrentVersionTransition']['StorageClass'].nil? ? 'GLACIER' : rule['NonCurrentVersionTransition']['StorageClass']
+                        StorageClass rule['NoncurrentVersionTransition']['StorageClass'].nil? ? 'GLACIER' : rule['NoncurrentVersionTransition']['StorageClass']
                       }
                     end
                   end

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -10,11 +10,11 @@ module Fog
         #     * ID [String] Unique identifier for the rule
         #     * Prefix [String] Prefix identifying one or more objects to which the rule applies
         #     * Enabled [Boolean] if rule is currently being applied
-        #     * Expiration [Hash] Container for the object expiration rule.
+        #     * [NonCurrentVersion]Expiration [Hash] Container for the object expiration rule.
         #       * Days [Integer] lifetime, in days, of the objects that are subject to the rule
         #       * Date [Date] Indicates when the specific rule take effect.
         #         The date value must conform to the ISO 8601 format. The time is always midnight UTC.
-        #     * Transition [Hash] Container for the transition rule that describes when objects transition
+        #     * [NonCurrentVersion]Transition [Hash] Container for the transition rule that describes when objects transition
         #       to the Glacier storage class
         #       * Days [Integer] lifetime, in days, of the objects that are subject to the rule
         #       * Date [Date] Indicates when the specific rule take effect.
@@ -43,6 +43,19 @@ module Fog
                         Expiration { Date rule['Expiration']['Date'].is_a?(Time) ? rule['Expiration']['Date'].utc.iso8601 : Time.parse(rule['Expiration']['Date']).utc.iso8601 }
                       end
                     end
+                    if rule['NonCurrentVersionExpiration']
+                      if rule['NonCurrentVersoinExpiration']['Days']
+                        NonCurrentVersoinExpiration { Days rule['NonCurrentVersoinExpiration']['Days'] }
+                      elsif rule['NonCurrentVersoinExpiration']['Date']
+                        NonCurrentVersoinExpiration {
+                          if Date rule['NonCurrentVersoinExpiration']['Date'].is_a?(Time)
+                            rule['NonCurrentVersoinExpiration']['Date'].utc.iso8601
+                          else
+                            Time.parse(rule['NonCurrentVersoinExpiration']['Date']).utc.iso8601
+                          end
+                        }
+                      end
+                    end
                     if rule['Transition']
                       Transition {
                         if rule['Transition']['Days']
@@ -51,6 +64,16 @@ module Fog
                           Date rule['Transition']['Date'].is_a?(Time) ? time.utc.iso8601 : Time.parse(time).utc.iso8601
                         end
                         StorageClass rule['Transition']['StorageClass'].nil? ? 'GLACIER' : rule['Transition']['StorageClass']
+                      }
+                    end
+                    if rule['NonCurrentVersionTransition']
+                      NonCurrentVersionTransition {
+                        if rule['NonCurrentVersionTransition']['Days']
+                          Days rule['NonCurrentVersionTransition']['Days']
+                        elsif rule['NonCurrentVersionTransition']['Date']
+                          Date rule['NonCurrentVersionTransition']['Date'].is_a?(Time) ? time.utc.iso8601 : Time.parse(time).utc.iso8601
+                        end
+                        StorageClass rule['NonCurrentVersionTransition']['StorageClass'].nil? ? 'GLACIER' : rule['NonCurrentVersionTransition']['StorageClass']
                       }
                     end
                   end

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -277,7 +277,7 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
         Fog::Storage[:aws].put_bucket_lifecycle(@aws_bucket_name, lifecycle)
         Fog::Storage[:aws].get_bucket_lifecycle(@aws_bucket_name).body
       end
-      lifecycle = {'Rules' => [{'ID' => 'test rule', 'Prefix' => '/prefix', 'Enabled' => true, 'NonCurrentVersionExpiration' => {'Days' => 42}, 'NonCurrentVersionTransition' => {'Days' => 6, 'StorageClass'=>'GLACIER'}}]}
+      lifecycle = {'Rules' => [{'ID' => 'test rule', 'Prefix' => '/prefix', 'Enabled' => true, 'NoncurrentVersionExpiration' => {'NoncurrentDays' => 42}, 'NoncurrentVersionTransition' => {'NoncurrentDays' => 6, 'StorageClass'=>'GLACIER'}}]}
       tests('versioned transition').returns(lifecycle) do
         Fog::Storage[:aws].put_bucket_lifecycle(@aws_bucket_name, lifecycle)
         Fog::Storage[:aws].get_bucket_lifecycle(@aws_bucket_name).body

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -277,6 +277,11 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
         Fog::Storage[:aws].put_bucket_lifecycle(@aws_bucket_name, lifecycle)
         Fog::Storage[:aws].get_bucket_lifecycle(@aws_bucket_name).body
       end
+      lifecycle = {'Rules' => [{'ID' => 'test rule', 'Prefix' => '/prefix', 'Enabled' => true, 'NonCurrentVersionExpiration' => {'Days' => 42}, 'NonCurrentVersionTransition' => {'Days' => 6, 'StorageClass'=>'GLACIER'}}]}
+      tests('versioned transition').returns(lifecycle) do
+        Fog::Storage[:aws].put_bucket_lifecycle(@aws_bucket_name, lifecycle)
+        Fog::Storage[:aws].get_bucket_lifecycle(@aws_bucket_name).body
+      end
       lifecycle = {'Rules' => [{'ID' => 'test rule', 'Prefix' => '/prefix', 'Enabled' => true, 'Expiration' => {'Date' => '2012-12-31T00:00:00.000Z'}}]}
       tests('date').returns(lifecycle) do
         Fog::Storage[:aws].put_bucket_lifecycle(@aws_bucket_name, lifecycle)


### PR DESCRIPTION
S3 has lifecycle policies for versioned objects that fog didn't support. This supports writing & parsing lifecycle specs for non-current versions of objects.

An example:
```ruby
require 'fog/aws'
s3 = Fog::Storage[:aws]
b = s3.directories.get('cmtestlifecycle')
lifecycle = { 'Rules' => [ { 'ID' => 'one-month-retention', 'Enabled' => true, 'NoncurrentVersionExpiration' => {'NoncurrentDays' => 30} } ] }
s3.put_bucket_lifecycle b.key, lifecycle
res = s3.get_bucket_lifecycle(b.key)
```