### PR TITLE
When not specified, region for a bucket should be DEFAULT_REGION.

### DIFF
--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -31,7 +31,7 @@ module Fog
         end
 
         def location
-          @location ||= (bucket_location || self.service.region)
+          @location ||= (bucket_location || AWS::DEFAULT_REGION)
         end
 
         # NOTE: you can't change the region once the bucket is created

--- a/tests/models/storage/directory_tests.rb
+++ b/tests/models/storage/directory_tests.rb
@@ -9,6 +9,10 @@ Shindo.tests("Storage[:aws] | directory", ["aws"]) do
       @instance.public_url
     end
 
+    tests('#location').returns('us-east-1') do # == Fog::AWS::Storage::DEFAULT_REGION
+      @instance.location
+    end
+
     @instance.acl = 'public-read'
     @instance.save
 


### PR DESCRIPTION
As detailed in #208, buckets without location constraints should default to the AWS default region and not that used by the current connection.