### PR TITLE
Fix for bug where retrying a chunked put_object request would fail.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -644,6 +644,7 @@ module Fog
           #we must also reset the signature
           def rewind
             self.signature = initial_signature
+            self.finished = false
             body.rewind
           end
 


### PR DESCRIPTION
If a chunked put_object request fails, all subsequent retries also fail due to the "finished" flag not being reset. Subsequent attempts upload 0 bytes which AWS rejects as not matching the header.