### PR TITLE
Security Group perms of FromPort 0 and ToPort -1

### DIFF
--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -83,8 +83,8 @@ module Fog
           requires_one :name, :group_id
 
           ip_permission = {
-            'FromPort'   => range.min,
-            'ToPort'     => range.max,
+            'FromPort'   => range.begin,
+            'ToPort'     => range.end,
             'IpProtocol' => options[:ip_protocol] || 'tcp'
           }
 
@@ -197,8 +197,8 @@ module Fog
           requires_one :name, :group_id
 
           ip_permission = {
-            'FromPort'   => range.min,
-            'ToPort'     => range.max,
+            'FromPort'   => range.begin,
+            'ToPort'     => range.end,
             'IpProtocol' => options[:ip_protocol] || 'tcp'
           }
 


### PR DESCRIPTION
Security Group perms of FromPort 0 and ToPort -1
    
Fix generation of the FromPort and ToPort paramters when authorizing or revoking permissions on a security group.
    
Using `min` and `max` to get the parts of a range can somtimes return nil, using `begin` and `end` will always return the actual values the range was created with
    
Example: `(0..-1).min` is nil and `(0..-1).max` is also nil
    
Error message from AWS would be:
    
Invalid value 'Must specify both from and to ports with ICMP.' for portRange
