### PR TITLE
do not make requests if mocked.

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -6,8 +6,7 @@ module Fog
       module ServiceMethods
         def fetch_credentials(options)
           if options[:use_iam_profile] && Fog.mocking?
-            mock_iam = {:use_iam_profile => true, :aws_access_key_id => "mock-iam-role", :aws_secret_access_key => "mock-iam-role"}
-            return options.merge(mock_iam)
+            Fog::Compute::AWS::Mock.data[:iam_role_based_creds]
           end
           if options[:use_iam_profile]
             begin

--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -5,6 +5,10 @@ module Fog
       INSTANCE_METADATA_PATH = "/latest/meta-data/iam/security-credentials/"
       module ServiceMethods
         def fetch_credentials(options)
+          if options[:use_iam_profile] && Fog.mocking?
+            mock_iam = {:use_iam_profile => true, :aws_access_key_id => "mock-iam-role", :aws_secret_access_key => "mock-iam-role"}
+            return options.merge(mock_iam)
+          end
           if options[:use_iam_profile]
             begin
               connection = options[:connection] || Excon.new(INSTANCE_METADATA_HOST)

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -1,5 +1,6 @@
 Shindo.tests('AWS | credentials', ['aws']) do
   old_mock_value = Excon.defaults[:mock]
+  fog_was_mocked = Fog.mocking?
   Excon.stubs.clear
   Fog.mock!
   begin
@@ -52,5 +53,6 @@ Shindo.tests('AWS | credentials', ['aws']) do
   ensure
     Excon.stubs.clear
     Excon.defaults[:mock] = old_mock_value
+    Fog.unmock! if !fog_was_mocked
   end
 end

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -1,7 +1,7 @@
 Shindo.tests('AWS | credentials', ['aws']) do
   old_mock_value = Excon.defaults[:mock]
   Excon.stubs.clear
-
+  Fog.mock!
   begin
     Excon.defaults[:mock] = true
     default_credentials = Fog::Compute::AWS.fetch_credentials({})
@@ -15,6 +15,7 @@ Shindo.tests('AWS | credentials', ['aws']) do
       'Expiration' => expires_at.xmlschema
     }
 
+    Fog::Compute::AWS::Mock.data[:iam_role_based_creds] = credentials
     Excon.stub({:method => :get, :path => "/latest/meta-data/iam/security-credentials/arole"}, {:status => 200, :body => Fog::JSON.encode(credentials)})
 
     tests("#fetch_credentials") do


### PR DESCRIPTION
Doing a `compute.servers` should work according as expected in mock mode when using it with an iam role (ie `use_iam_profile`), but currently the credentials_fetcher is making real requests. This just mocks the api keys that it would get in the real mode.