### PR TITLE
Fix for empty ETag values

### DIFF
--- a/lib/fog/aws/parsers/storage/get_bucket.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket.rb
@@ -26,7 +26,7 @@ module Fog
             when 'DisplayName', 'ID'
               @object['Owner'][name] = value
             when 'ETag'
-              @object[name] = value.gsub('"', '')
+              @object[name] = value.gsub('"', '') if value != nil
             when 'IsTruncated'
               if value == 'true'
                 @response['IsTruncated'] = true


### PR DESCRIPTION
Fog aws fails if API response contains empty ETag tags. It may cause when working with S3 clones (like minio in my case), that not provides ETags in their API answer.