### PR TITLE
Allow case-insensitive record comparison

### DIFF
--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -93,7 +93,7 @@ module Fog
           (data['ResourceRecordSets'] || []).map do |record_data|
             record = new(record_data)
 
-            if (record.name == record_name) &&
+            if (record.name.casecmp(record_name) == 0) &&
                 (record_type.nil? || (record.type == record_type)) &&
                 (record_identifier.nil? || (record.set_identifier == record_identifier))
               record


### PR DESCRIPTION
I want to change to case-insensitive comparison to allow this use case:
```
"server1.example.com".casecmp("SERVER1.example.com") == 0
```