### PR TITLE
RDS test fixes

### DIFF
--- a/lib/fog/aws/requests/rds/copy_db_snapshot.rb
+++ b/lib/fog/aws/requests/rds/copy_db_snapshot.rb
@@ -37,14 +37,14 @@ module Fog
         def copy_db_snapshot(source_db_snapshot_identifier, target_db_snapshot_identifier, copy_tags = false)
           response = Excon::Response.new
           response.status = 200
-          snapshot_id = Fog::AWS::Mock.snapshot_id
-          data = {
-            'snapshotId'  => snapshot_id,
-          }
+          snapshot_id =  Fog::AWS::Mock.snapshot_id
+          data = self.data[:snapshots]["#{source_db_snapshot_identifier}"]
+          data['DBSnapshotIdentifier'] = snapshot_id
           self.data[:snapshots][snapshot_id] = data
           response.body = {
-            'requestId' => Fog::AWS::Mock.request_id
-          }.merge!(data)
+            'requestId' => Fog::AWS::Mock.request_id,
+            'CopyDBSnapshotResult' => {'DBSnapshot' => data.dup}
+          }
           response
         end
       end

--- a/tests/requests/rds/helper.rb
+++ b/tests/requests/rds/helper.rb
@@ -138,7 +138,7 @@ class AWS
 
       SNAPSHOT = {
         'AllocatedStorage' => Integer,
-        'AvailabilityZone' => String,
+        'AvailabilityZone' => Fog::Nullable::String,
         'DBInstanceIdentifier' => String,
         'DBSnapshotIdentifier' => String,
         'EngineVersion' => String,
@@ -146,10 +146,11 @@ class AWS
         'InstanceCreateTime' => Time,
         'Iops' => Fog::Nullable::Integer,
         'MasterUsername' => String,
-        'Port' => Integer,
+        'Port' => Fog::Nullable::Integer,
         'SnapshotCreateTime' => Fog::Nullable::Time,
         'Status' => String,
-        'SnapshotType' => String
+        'SnapshotType' => String,
+        'StorageType' => String,
       }
 
       INSTANCE = {


### PR DESCRIPTION
Some RDS tests were failing due to a bad mock returned with copy_db_snapshot, and a couple of old/incorrect formats for said snapshots.