### PR TITLE
Change DBSubnetGroup to DBSubnetGroupName model cluster while creation

### DIFF
--- a/lib/fog/aws/models/rds/cluster.rb
+++ b/lib/fog/aws/models/rds/cluster.rb
@@ -72,7 +72,7 @@ module Fog
             'BackupRetentionPeriod'      => backup_retention_period,
             'DBClusterIdentifier'        => identity,
             'DBClusterParameterGroup'    => db_cluster_parameter_group,
-            'DBSubnetGroupName'              => db_subnet_group,
+            'DBSubnetGroupName'          => db_subnet_group,
             'Endpoint'                   => endpoint,
             'Engine'                     => engine,
             'EngineVersion'              => engine_version,

--- a/lib/fog/aws/models/rds/cluster.rb
+++ b/lib/fog/aws/models/rds/cluster.rb
@@ -8,7 +8,7 @@ module Fog
         attribute :backup_retention_period,      :aliases => 'BackupRetentionPeriod',     :type => :integer
         attribute :db_cluster_members,           :aliases => 'DBClusterMembers',          :type => :array
         attribute :db_cluster_parameter_group,   :aliases => 'DBClusterParameterGroup'
-        attribute :db_subnet_group,              :aliases => 'DBSubnetGroup'
+        attribute :db_subnet_group,              :aliases => 'DBSubnetGroupName'
         attribute :endpoint,                     :aliases => 'Endpoint'
         attribute :engine,                       :aliases => 'Engine'
         attribute :engine_version,               :aliases => 'EngineVersion'
@@ -72,7 +72,7 @@ module Fog
             'BackupRetentionPeriod'      => backup_retention_period,
             'DBClusterIdentifier'        => identity,
             'DBClusterParameterGroup'    => db_cluster_parameter_group,
-            'DBSubnetGroup'              => db_subnet_group,
+            'DBSubnetGroupName'              => db_subnet_group,
             'Endpoint'                   => endpoint,
             'Engine'                     => engine,
             'EngineVersion'              => engine_version,


### PR DESCRIPTION
 >> `connection.clusters.create(......, :db_subnet_group=>'subnetgroup-18')`
_Error thrown is_ :- 
 >>` Fog::AWS::RDS::Error: InvalidParameterCombination => Database is in vpc-c046a0a9, but Ec2 Security Group sg-5831ce31 is in vpc-91a95df8`

- As the name of `SubnetGroup` at create_db_cluster.rb is DBSubnetGroupName
- Mapping at cluster.rb is made to **DBSubnetGroupName**

