### PR TITLE
Skip multipart if body size is less than chunk. 

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -205,7 +205,7 @@ module Fog
           options['x-amz-storage-class'] = storage_class if storage_class
           options.merge!(encryption_headers)
 
-          if multipart_chunk_size && body.respond_to?(:read)
+          if multipart_chunk_size && get_body_size(body) >= multipart_chunk_size && body.respond_to?(:read)
             data = multipart_save(options)
             merge_attributes(data.body)
           else

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -209,6 +209,9 @@ module Fog
           options['x-amz-storage-class'] = storage_class if storage_class
           options.merge!(encryption_headers)
 
+          # With a single PUT operation you can upload objects up to 5 GB in size. Automatically set MP for larger objects.
+          multipart_chunk_size=5242880 if !multipart_chunk_size && Fog::Storage.get_body_size(body) > 5368709120
+
           if multipart_chunk_size && Fog::Storage.get_body_size(body) >= multipart_chunk_size && body.respond_to?(:read)
             data = multipart_save(options)
             merge_attributes(data.body)

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -27,7 +27,11 @@ module Fog
 
         # @note Chunk size to use for multipart uploads.
         #     Use small chunk sizes to minimize memory. E.g. 5242880 = 5mb
-        attr_accessor :multipart_chunk_size
+        attr_reader :multipart_chunk_size
+        def multipart_chunk_size=(mp_chunk_size)
+          raise ArgumentError.new("minimum multipart_chunk_size is 5242880") if mp_chunk_size < 5242880
+          @multipart_chunk_size = mp_chunk_size
+        end
 
         def acl
           requires :directory, :key

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -205,7 +205,7 @@ module Fog
           options['x-amz-storage-class'] = storage_class if storage_class
           options.merge!(encryption_headers)
 
-          if multipart_chunk_size && get_body_size(body) >= multipart_chunk_size && body.respond_to?(:read)
+          if multipart_chunk_size && Fog::Storage.get_body_size(body) >= multipart_chunk_size && body.respond_to?(:read)
             data = multipart_save(options)
             merge_attributes(data.body)
           else


### PR DESCRIPTION
Fixes https://github.com/fog/fog/issues/3899

@geemus did not write a test for this, spent a bit of time dabbling with shindo(nt) and have a real (non mock) test but couldn't get AWS auth params passed to run the test. Have tested manually with 0b, 5242879b and 10m files and all upload correctly with multipart being set on file size >= multipart_chunk.
