### PR TITLE
Add gestion of egress security group rules

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -151,6 +151,7 @@ module Fog
       request :register_image
       request :request_spot_instances
       request :reset_network_interface_attribute
+      request :revoke_security_group_egress
       request :revoke_security_group_ingress
       request :run_instances
       request :terminate_instances

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -54,6 +54,7 @@ module Fog
       request :attach_classic_link_vpc
       request :attach_internet_gateway
       request :attach_volume
+      request :authorize_security_group_egress
       request :authorize_security_group_ingress
       request :cancel_spot_instance_requests
       request :create_dhcp_options

--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -200,7 +200,23 @@ module Fog
 
           ip_permission = fetch_ip_permission(range, options)
 
+          if options[:direction].nil? || options[:direction] == 'ingress'
+            revoke_port_range_ingress group_id, ip_permission
+          elsif options[:direction] == 'egress'
+            revoke_port_range_egress group_id, ip_permission
+          end
+        end
+
+        def revoke_port_range_ingress(group_id, ip_permission)
           service.revoke_security_group_ingress(
+            name,
+            'GroupId'       => group_id,
+            'IpPermissions' => [ ip_permission ]
+          )
+        end
+
+        def revoke_port_range_egress(group_id, ip_permission)
+          service.revoke_security_group_egress(
             name,
             'GroupId'       => group_id,
             'IpPermissions' => [ ip_permission ]

--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -84,7 +84,23 @@ module Fog
 
           ip_permission = fetch_ip_permission(range, options)
 
+          if options[:direction].nil? || options[:direction] == 'ingress'
+            authorize_port_range_ingress group_id, ip_permission
+          elsif options[:direction] == 'egress'
+            authorize_port_range_egress group_id, ip_permission
+          end
+        end
+
+        def authorize_port_range_ingress(group_id, ip_permission)
           service.authorize_security_group_ingress(
+            name,
+            'GroupId'       => group_id,
+            'IpPermissions' => [ ip_permission ]
+          )
+        end
+
+        def authorize_port_range_egress(group_id, ip_permission)
+          service.authorize_security_group_egress(
             name,
             'GroupId'       => group_id,
             'IpPermissions' => [ ip_permission ]

--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -82,21 +82,7 @@ module Fog
         def authorize_port_range(range, options = {})
           requires_one :name, :group_id
 
-          ip_permission = {
-            'FromPort'   => range.begin,
-            'ToPort'     => range.end,
-            'IpProtocol' => options[:ip_protocol] || 'tcp'
-          }
-
-          if options[:group].nil?
-            ip_permission['IpRanges'] = [
-              { 'CidrIp' => options[:cidr_ip] || '0.0.0.0/0' }
-            ]
-          else
-            ip_permission['Groups'] = [
-              group_info(options[:group])
-            ]
-          end
+          ip_permission = fetch_ip_permission(range, options)
 
           service.authorize_security_group_ingress(
             name,
@@ -196,21 +182,7 @@ module Fog
         def revoke_port_range(range, options = {})
           requires_one :name, :group_id
 
-          ip_permission = {
-            'FromPort'   => range.begin,
-            'ToPort'     => range.end,
-            'IpProtocol' => options[:ip_protocol] || 'tcp'
-          }
-
-          if options[:group].nil?
-            ip_permission['IpRanges'] = [
-              { 'CidrIp' => options[:cidr_ip] || '0.0.0.0/0' }
-            ]
-          else
-            ip_permission['Groups'] = [
-              group_info(options[:group])
-            ]
-          end
+          ip_permission = fetch_ip_permission(range, options)
 
           service.revoke_security_group_ingress(
             name,
@@ -313,6 +285,25 @@ module Fog
           end
 
           info
+        end
+
+        def fetch_ip_permission(range, options)
+          ip_permission = {
+            'FromPort'   => range.begin,
+            'ToPort'     => range.end,
+            'IpProtocol' => options[:ip_protocol] || 'tcp'
+          }
+
+          if options[:group].nil?
+            ip_permission['IpRanges'] = [
+              { 'CidrIp' => options[:cidr_ip] || '0.0.0.0/0' }
+            ]
+          else
+            ip_permission['Groups'] = [
+              group_info(options[:group])
+            ]
+          end
+          ip_permission
         end
       end
     end

--- a/lib/fog/aws/requests/compute/authorize_security_group_egress.rb
+++ b/lib/fog/aws/requests/compute/authorize_security_group_egress.rb
@@ -1,0 +1,112 @@
+module Fog
+  module Compute
+    class AWS
+      class Real
+        require 'fog/aws/parsers/compute/basic'
+
+        # Add permissions to a security group
+        #
+        # ==== Parameters
+        # * group_name<~String> - Name of group, optional (can also be specifed as GroupName in options)
+        # * options<~Hash>:
+        #   * 'GroupName'<~String> - Name of security group to modify
+        #   * 'GroupId'<~String> - Id of security group to modify
+        #   * 'SourceSecurityGroupName'<~String> - Name of security group to authorize
+        #   * 'SourceSecurityGroupOwnerId'<~String> - Name of owner to authorize
+        #   or
+        #   * 'CidrIp'<~String> - CIDR range
+        #   * 'FromPort'<~Integer> - Start of port range (or -1 for ICMP wildcard)
+        #   * 'IpProtocol'<~String> - Ip protocol, must be in ['tcp', 'udp', 'icmp']
+        #   * 'ToPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
+        #   or
+        #   * 'IpPermissions'<~Array>:
+        #     * permission<~Hash>:
+        #       * 'FromPort'<~Integer> - Start of port range (or -1 for ICMP wildcard)
+        #       * 'Groups'<~Array>:
+        #         * group<~Hash>:
+        #           * 'GroupName'<~String> - Name of security group to authorize
+        #           * 'UserId'<~String> - Name of owner to authorize
+        #       * 'IpProtocol'<~String> - Ip protocol, must be in ['tcp', 'udp', 'icmp']
+        #       * 'IpRanges'<~Array>:
+        #         * ip_range<~Hash>:
+        #           * 'CidrIp'<~String> - CIDR range
+        #       * 'ToPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
+        #
+        # === Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'requestId'<~String> - Id of request
+        #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AuthorizeSecurityGroupEgress.html]
+        def authorize_security_group_egress(group_name, options = {})
+          options = Fog::AWS.parse_security_group_options(group_name, options)
+
+          if ip_permissions = options.delete('IpPermissions')
+            options.merge!(indexed_ip_permissions_params(ip_permissions))
+          end
+
+          request({
+            'Action'    => 'AuthorizeSecurityGroupEgress',
+            :idempotent => true,
+            :parser     => Fog::Parsers::Compute::AWS::Basic.new
+          }.merge!(options))
+        end
+      end
+
+      class Mock
+        def authorize_security_group_egress(group_name, options = {})
+          options = Fog::AWS.parse_security_group_options(group_name, options)
+          if options.key?('GroupName')
+            group_name = options['GroupName']
+          else
+            group_name = self.data[:security_groups].reject { |k,v| v['groupId'] != options['GroupId'] } .keys.first
+          end
+
+          response = Excon::Response.new
+          group = self.data[:security_groups][group_name] || raise(Fog::Compute::AWS::NotFound.new("The security group '#{group_name}' does not exist"))
+
+          verify_permission_options(options, group['vpcId'] != nil)
+
+          normalized_permissions = normalize_permissions(options)
+
+          normalized_permissions.each do |permission|
+            if matching_group_permission = find_matching_permission_egress(group, permission)
+              if permission['groups'].any? {|pg| matching_group_permission['groups'].include?(pg) }
+                raise Fog::Compute::AWS::Error, "InvalidPermission.Duplicate => The permission '123' has already been authorized in the specified group"
+              end
+
+              if permission['ipRanges'].any? {|pr| matching_group_permission['ipRanges'].include?(pr) }
+                raise Fog::Compute::AWS::Error, "InvalidPermission.Duplicate => The permission '123' has already been authorized in the specified group"
+              end
+            end
+          end
+
+          normalized_permissions.each do |permission|
+            if matching_group_permission = find_matching_permission_egress(group, permission)
+              matching_group_permission['groups'] += permission['groups']
+              matching_group_permission['ipRanges'] += permission['ipRanges']
+            else
+              group['ipPermissionsEgress'] << permission
+            end
+          end
+
+          response.status = 200
+          response.body = {
+            'requestId' => Fog::AWS::Mock.request_id,
+            'return'    => true
+          }
+          response
+        end
+
+        def find_matching_permission_egress(group, permission)
+          group['ipPermissionsEgress'].find do |group_permission|
+            permission['ipProtocol'] == group_permission['ipProtocol'] &&
+              permission['fromPort'] == group_permission['fromPort'] &&
+              permission['toPort'] == group_permission['toPort']
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/compute/revoke_security_group_egress.rb
+++ b/lib/fog/aws/requests/compute/revoke_security_group_egress.rb
@@ -1,0 +1,98 @@
+module Fog
+  module Compute
+    class AWS
+      class Real
+        require 'fog/aws/parsers/compute/basic'
+
+        # Remove permissions from a security group
+        #
+        # ==== Parameters
+        # * group_name<~String> - Name of group, optional (can also be specifed as GroupName in options)
+        # * options<~Hash>:
+        #   * 'GroupName'<~String> - Name of security group to modify
+        #   * 'GroupId'<~String> - Id of security group to modify
+        #   * 'SourceSecurityGroupName'<~String> - Name of security group to authorize
+        #   * 'SourceSecurityGroupOwnerId'<~String> - Name of owner to authorize
+        #   or
+        #   * 'CidrIp'<~String> - CIDR range
+        #   * 'FromPort'<~Integer> - Start of port range (or -1 for ICMP wildcard)
+        #   * 'IpProtocol'<~String> - Ip protocol, must be in ['tcp', 'udp', 'icmp']
+        #   * 'ToPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
+        #   or
+        #   * 'IpPermissions'<~Array>:
+        #     * permission<~Hash>:
+        #       * 'FromPort'<~Integer> - Start of port range (or -1 for ICMP wildcard)
+        #       * 'Groups'<~Array>:
+        #         * group<~Hash>:
+        #           * 'GroupName'<~String> - Name of security group to authorize
+        #           * 'UserId'<~String> - Name of owner to authorize
+        #       * 'IpProtocol'<~String> - Ip protocol, must be in ['tcp', 'udp', 'icmp']
+        #       * 'IpRanges'<~Array>:
+        #         * ip_range<~Hash>:
+        #           * 'CidrIp'<~String> - CIDR range
+        #       * 'ToPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
+        #
+        # === Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'requestId'<~String> - Id of request
+        #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RevokeSecurityGroupEgress.html]
+        def revoke_security_group_egress(group_name, options = {})
+          options = Fog::AWS.parse_security_group_options(group_name, options)
+
+          if ip_permissions = options.delete('IpPermissions')
+            options.merge!(indexed_ip_permissions_params(ip_permissions))
+          end
+
+          request({
+            'Action'    => 'RevokeSecurityGroupEgress',
+            :idempotent => true,
+            :parser     => Fog::Parsers::Compute::AWS::Basic.new
+          }.merge!(options))
+        end
+      end
+
+      class Mock
+        def revoke_security_group_egress(group_name, options = {})
+          options = Fog::AWS.parse_security_group_options(group_name, options)
+          if options.key?('GroupName')
+            group_name = options['GroupName']
+          else
+            group_name = self.data[:security_groups].reject { |k,v| v['groupId'] != options['GroupId'] } .keys.first
+          end
+
+          response = Excon::Response.new
+          group = self.data[:security_groups][group_name]
+
+          if group
+            verify_permission_options(options, group['vpcId'] != nil)
+
+            normalized_permissions = normalize_permissions(options)
+
+            normalized_permissions.each do |permission|
+              if matching_permission = find_matching_permission_egress(group, permission)
+                matching_permission['ipRanges'] -= permission['ipRanges']
+                matching_permission['groups'] -= permission['groups']
+
+                if matching_permission['ipRanges'].empty? && matching_permission['groups'].empty?
+                  group['ipPermissionsEgress'].delete(matching_permission)
+                end
+              end
+            end
+
+            response.status = 200
+            response.body = {
+              'requestId' => Fog::AWS::Mock.request_id,
+              'return'    => true
+            }
+            response
+          else
+            raise Fog::Compute::AWS::NotFound.new("The security group '#{group_name}' does not exist")
+          end
+        end
+      end
+    end
+  end
+end

--- a/tests/models/compute/security_group_tests.rb
+++ b/tests/models/compute/security_group_tests.rb
@@ -38,13 +38,25 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
     test("authorize access at a port range (egress rule)") do
       @group.authorize_port_range(5000..6000, :direction => 'egress')
       @group.reload
-      @group.ip_permissions_egress.size == 1
+      ip_permission_egress = @group.ip_permissions_egress.find do |permission|
+        permission['fromPort'] == 5000 &&
+          permission['toPort'] == 6000 &&
+          permission['ipProtocol'] == 'tcp' &&
+          permission['ipRanges'] == [{ 'cidrIp' => '0.0.0.0/0' }]
+      end
+      !ip_permission_egress.nil?
     end
 
     test("revoke access at a port range (egress rule)") do
       @group.revoke_port_range(5000..6000, :direction => 'egress')
       @group.reload
-      @group.ip_permissions_egress.empty?
+      ip_permission_egress = @group.ip_permissions_egress.find do |permission|
+        permission['fromPort'] == 5000 &&
+          permission['toPort'] == 6000 &&
+          permission['ipProtocol'] == 'tcp' &&
+          permission['ipRanges'] == [{ 'cidrIp' => '0.0.0.0/0' }]
+      end
+      ip_permission_egress.nil?
     end
 
     group_forms = [

--- a/tests/models/compute/security_group_tests.rb
+++ b/tests/models/compute/security_group_tests.rb
@@ -35,6 +35,12 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
       @group.ip_permissions.empty?
     end
 
+    test("authorize access at a port range (egress rule)") do
+      @group.authorize_port_range(5000..6000, direction: 'egress')
+      @group.reload
+      @group.ip_permissions_egress.size == 1
+    end
+
     group_forms = [
       "#{@other_group.owner_id}:#{@other_group.group_id}", # deprecated form
       @other_group.group_id,

--- a/tests/models/compute/security_group_tests.rb
+++ b/tests/models/compute/security_group_tests.rb
@@ -36,13 +36,13 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
     end
 
     test("authorize access at a port range (egress rule)") do
-      @group.authorize_port_range(5000..6000, direction: 'egress')
+      @group.authorize_port_range(5000..6000, :direction => 'egress')
       @group.reload
       @group.ip_permissions_egress.size == 1
     end
 
     test("revoke access at a port range (egress rule)") do
-      @group.revoke_port_range(5000..6000, direction: 'egress')
+      @group.revoke_port_range(5000..6000, :direction => 'egress')
       @group.reload
       @group.ip_permissions_egress.empty?
     end

--- a/tests/models/compute/security_group_tests.rb
+++ b/tests/models/compute/security_group_tests.rb
@@ -41,6 +41,12 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
       @group.ip_permissions_egress.size == 1
     end
 
+    test("revoke access at a port range (egress rule)") do
+      @group.revoke_port_range(5000..6000, direction: 'egress')
+      @group.reload
+      @group.ip_permissions_egress.empty?
+    end
+
     group_forms = [
       "#{@other_group.owner_id}:#{@other_group.group_id}", # deprecated form
       @other_group.group_id,


### PR DESCRIPTION
Hi guys !

Just a little PR to add gestion of egress security group rules (authorize / revoke).

For ensure retro-compatibility I add an optional parameters that indicate if the rules is ingress or egress, but then it's less better abstraction of AWS API. WDYT about this ?

I'm not sure that is the best way for implement this functionality, I will be listening you, feel free to tell me if I'm doing something wrong.
Thanks.