### PR TITLE
Cloud Formation: support for change sets, stack policy and other missing calls.  

### DIFF
--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -7,14 +7,19 @@ module Fog
       recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
 
       request_path 'fog/aws/requests/cloud_formation'
+      request :create_change_set
       request :create_stack
       request :update_stack
+      request :delete_change_set
       request :delete_stack
+      request :describe_change_set
       request :describe_stack_events
       request :describe_stack_resources
       request :describe_stacks
+      request :execute_change_set
       request :get_template
       request :validate_template
+      request :list_change_sets
       request :list_stacks
       request :list_stack_resources
 

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -7,17 +7,24 @@ module Fog
       recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
 
       request_path 'fog/aws/requests/cloud_formation'
+      request :cancel_update_stack
+      request :continue_update_rollback
       request :create_change_set
       request :create_stack
       request :update_stack
       request :delete_change_set
       request :delete_stack
+      request :describe_account_limits
       request :describe_change_set
       request :describe_stack_events
+      request :describe_stack_resource
       request :describe_stack_resources
       request :describe_stacks
+      request :estimate_template_cost
       request :execute_change_set
       request :get_template
+      request :get_template_summary
+      request :signal_resource
       request :validate_template
       request :list_change_sets
       request :list_stacks

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -22,8 +22,10 @@ module Fog
       request :describe_stacks
       request :estimate_template_cost
       request :execute_change_set
+      request :get_stack_policy
       request :get_template
       request :get_template_summary
+      request :set_stack_policy
       request :signal_resource
       request :validate_template
       request :list_change_sets

--- a/lib/fog/aws/parsers/cloud_formation/create_change_set.rb
+++ b/lib/fog/aws/parsers/cloud_formation/create_change_set.rb
@@ -1,0 +1,16 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class CreateChangeSet < Fog::Parsers::Base
+          def end_element(name)
+            case name
+            when 'RequestId', 'Id'
+              @response[name] = value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/describe_account_limits.rb
+++ b/lib/fog/aws/parsers/cloud_formation/describe_account_limits.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class DescribeAccountLimits < Fog::Parsers::Base
+          def reset
+            @limit = {}
+            @response = { 'AccountLimits' => [] }
+          end
+
+          def end_element(name)
+            case name
+            when 'Name', 'Value'
+              @limit[name] = value
+            when 'member'
+              @response['AccountLimits'] << @limit
+              @limit = {}
+            when 'RequestId'
+              @response[name] = value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/describe_change_set.rb
+++ b/lib/fog/aws/parsers/cloud_formation/describe_change_set.rb
@@ -4,7 +4,6 @@ module Fog
       module CloudFormation
         class DescribeChangeSet < Fog::Parsers::Base
           def reset
-            #@change_set = fresh_change_set
             @response = fresh_change_set
             reset_parameter
             reset_change

--- a/lib/fog/aws/parsers/cloud_formation/describe_change_set.rb
+++ b/lib/fog/aws/parsers/cloud_formation/describe_change_set.rb
@@ -1,0 +1,136 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class DescribeChangeSet < Fog::Parsers::Base
+          def reset
+            #@change_set = fresh_change_set
+            @response = fresh_change_set
+            reset_parameter
+            reset_change
+            reset_resource_change
+            reset_resource_change_detail
+            reset_resource_target_definition
+          end
+
+          def reset_parameter
+            @parameter = {}
+          end
+
+          def reset_change
+            @change = {}
+          end
+
+          def reset_resource_change
+            @resource_change = {'Details' => [], 'Scope' => [] }
+          end
+
+          def reset_resource_change_detail
+            @resource_change_detail = {}
+          end
+
+          def reset_resource_target_definition
+            @resource_target_definition = {}
+          end
+
+          def fresh_change_set
+            {'Capabilities' => [], 'Changes' => [], 'NotificationARNs' => [], 'Parameters' => [], 'Tags' => []}
+          end
+
+          def start_element(name, attrs=[])
+            super
+            case name
+            when 'Capabilities'
+              @in_capabilities = true
+            when 'Changes'
+              @in_changes = true
+            when 'ResourceChange'
+              @in_resource_change = true
+            when 'Scope'
+              @in_scope = true
+            when 'Details'
+              @in_details = true
+            when 'Target'
+              @in_target = true
+            when 'NotificationARNs'
+              @in_notification_arns = true
+            when 'Parameters'
+              @in_parameters = true
+            when 'Tags'
+              @in_tags = true
+            end
+          end
+
+          def end_element(name)
+            case name
+            when 'ChangeSetId', 'ChangeSetName', 'Description', 'ExecutionStatus', 'StackId', 'StackName', 'StatusReason'
+              @response[name] = value
+            when 'CreationTime'
+              @response[name] = Time.parse(value)
+            when 'member'
+              if @in_capabilities
+                @response['Capabilities'] << value
+              elsif @in_scope
+                @resource_change['Scope'] << value
+              elsif @in_notification_arns
+                @response['NotificationARNs'] << value
+              elsif @in_parameters
+                @response['Parameters'] << @parameter
+                reset_parameter
+              elsif @in_tags
+                @response['Tags'] << @tag
+                reset_tag
+              elsif @in_details
+                @resource_change['Details'] << @resource_change_detail
+                reset_resource_change_detail
+              elsif @in_changes
+                @response['Changes'] << @change
+                reset_change
+              end
+            when 'ParameterValue', 'ParameterKey'
+              @parameter[name] = value if @in_parameters
+            when 'Parameters'
+              @in_parameters = false
+            when 'Value', 'Key'
+              @tag[name] = value if @in_tags
+            when 'Tags'
+              @in_tags = false
+            when 'Capabilities'
+              @in_capabilities = false
+            when 'Scope'
+              @in_scope = false
+            when 'NotificationARNs'
+              @in_notification_arns = false
+            when 'Type'
+              @change[name] = value if @in_changes
+            when 'Changes'
+              @in_changes = false
+            when 'ResourceChange'
+              if @in_resource_change
+                @change[name] = @resource_change
+                @in_resource_change = false
+              end
+            when 'Action','LogicalResourceId','PhysicalResourceId','Replacement','ResourceType'
+              @resource_change[name] = value  if @in_resource_change
+            when 'Details'
+              @in_details = false
+            when 'CausingEntity','ChangeSource','Evaluation'
+              if @in_details
+                @resource_change_detail[name] = value
+              end
+            when 'Attribute','Name','RequiresRecreation'
+              if @in_target
+                @resource_target_definition[name] = value
+              end
+            when 'Target'
+              if @in_target
+                @resource_change_detail[name] = @resource_target_definition
+                @in_target = false
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/describe_stack_resource.rb
+++ b/lib/fog/aws/parsers/cloud_formation/describe_stack_resource.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class DescribeStackResource < Fog::Parsers::Base
+          def reset
+            @resource = {}
+            @response = { 'StackResourceDetail' => {} }
+          end
+
+          def end_element(name)
+            case name
+            when 'Description','LogicalResourceId', 'Metadata', 'PhysicalResourceId', 'ResourceStatus', 'ResourceStatusReason', 'ResourceType', 'StackId', 'StackName' 
+              @resource[name] = value
+            when 'StackResourceDetail'
+              @response['StackResourceDetail'] = @resource
+              @resource = {}
+            when 'RequestId'
+              @response[name] = value
+            when 'LastUpdatedTimestamp'
+              @resource[name] = Time.parse(value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/estimate_template_cost.rb
+++ b/lib/fog/aws/parsers/cloud_formation/estimate_template_cost.rb
@@ -2,12 +2,10 @@ module Fog
   module Parsers
     module AWS
       module CloudFormation
-        class Basic < Fog::Parsers::Base
+        class EstimateTemplateCost < Fog::Parsers::Base
           def end_element(name)
             case name
-            when 'RequestId'
-              @response[name] = value
-            when 'NextToken'
+            when 'RequestId', 'Url'
               @response[name] = value
             end
           end

--- a/lib/fog/aws/parsers/cloud_formation/get_stack_policy.rb
+++ b/lib/fog/aws/parsers/cloud_formation/get_stack_policy.rb
@@ -1,0 +1,16 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class GetStackPolicy < Fog::Parsers::Base
+          def end_element(name)
+            case name
+            when 'RequestId', 'StackPolicyBody'
+              @response[name] = value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/get_template_summary.rb
+++ b/lib/fog/aws/parsers/cloud_formation/get_template_summary.rb
@@ -1,0 +1,62 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class GetTemplateSummary < Fog::Parsers::Base
+          def reset
+            reset_parameter
+            @response = {'Capabilities' => [],'ResourceTypes' => '','Parameters' => []  }
+          end
+
+          def reset_parameter
+            @parameter = {'AllowedValues' => []}
+          end
+
+          def start_element(name, attrs=[])
+            super
+            case name
+            when 'Capabilities'
+              @in_capabilities = true
+            when 'Parameters'
+              @in_parameters = true
+            when 'ResourceTypes'
+              @in_resource_types = true
+            end
+          end
+
+          def end_element(name)
+            case name
+            when 'member'
+              if @in_capabilities
+                @response['Capabilities'] << value
+              elsif @in_resource_types
+                @response['ResourceTypes'] << value
+              elsif @in_parameters
+                @response['Parameters'] << @parameter
+                reset_parameter
+              end
+            when 'DefaultValue', 'NoEcho', 'ParameterKey', 'ParameterType', 'ParameterType'
+              @parameter[name] = value if @in_parameters
+            when 'Description'
+              if @in_parameters
+                @parameter[name] = value
+              else
+                @response[name] = value
+              end
+            when 'ParameterConstraints'
+              @parameter['AllowedValues'] << value  if @in_parameters
+            when 'RequestId'
+              @response[name] = value
+            when 'Parameters'
+              @in_parameters = false
+            when 'ResourceTypes'
+              @in_resource_types = false
+            when 'Capabilities'
+              @in_capabilities = false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/cloud_formation/list_change_sets.rb
+++ b/lib/fog/aws/parsers/cloud_formation/list_change_sets.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Parsers
+    module AWS
+      module CloudFormation
+        class ListChangeSets < Fog::Parsers::Base
+          def reset
+            @change_set = {}
+            @response = { 'Summaries' => [] }
+          end
+
+          def end_element(name)
+            case name
+            when 'ChangeSetId', 'ChangeSetName', 'Description', 'ExecutionStatus', 'StackId', 'StackName', 'Status', 'StackReason'
+              @change_set[name] = value
+            when 'member'
+              @response['Summaries'] << @change_set
+              @change_set = {}
+            when 'RequestId'
+              @response[name] = value
+            when 'CreationTime'
+              @change_set[name] = Time.parse(value)
+            when 'NextToken'
+              @response[name] = value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/cancel_update_stack.rb
+++ b/lib/fog/aws/requests/cloud_formation/cancel_update_stack.rb
@@ -4,17 +4,17 @@ module Fog
       class Real
         require 'fog/aws/parsers/cloud_formation/basic'
 
-        # Delete a stack.
+        # Cancels an update on the specified stack.
         #
-        # @param stack_name [String] Name of the stack to create.
+        # @param stack_name String] Name of the stack to cancel update.
         #
         # @return [Excon::Response]
         #
-        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_DeleteStack.html
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_CancelUpdateStack.html
 
-        def delete_stack(stack_name)
+        def cancel_update_stack(stack_name)
           request(
-            'Action'    => 'DeleteStack',
+            'Action'    => 'CancelUpdateStack',
             'StackName' => stack_name,
             :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
           )

--- a/lib/fog/aws/requests/cloud_formation/continue_update_rollback.rb
+++ b/lib/fog/aws/requests/cloud_formation/continue_update_rollback.rb
@@ -1,0 +1,26 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/basic'
+
+        # For a specified stack that is in the UPDATE_ROLLBACK_FAILED state,
+        # continues rolling it back to the UPDATE_ROLLBACK_COMPLETE state.
+        #
+        # @param stack_name [String] The name or the unique ID of the stack that you want to continue rolling back.
+        #
+        # @return [Excon::Response]
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_ContinueUpdateRollback.html
+
+        def continue_update_rollback(stack_name)
+          request(
+            'Action'    => 'ContinueUpdateRollback',
+            'StackName' => stack_name,
+            :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/create_change_set.rb
+++ b/lib/fog/aws/requests/cloud_formation/create_change_set.rb
@@ -1,0 +1,70 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/create_change_set'
+
+        # Create a Change Set.
+        #
+        # * stack_name [String] Name of the stack to create.
+        # * options [Hash]:
+        #   * ChangeSetName [String] The name of the change set.
+        #   * Description [String] A description to help you identify this change set.
+        #   * TemplateBody [String] Structure containing the template body.
+        #   or (one of the two Template parameters is required)
+        #   * TemplateURL [String] URL of file containing the template body.
+        #   * UsePreviousTemplate [Boolean] Reuse the template that is associated with the stack to create the change set.
+        #   * NotificationARNs [Array] List of SNS topics to publish events to.
+        #   * Parameters [Hash] Hash of providers to supply to template.
+        #
+        # @return [Excon::Response]:
+        #   * body [Hash:
+        #     * Id [String] - The Amazon Resource Name (ARN) of the change set
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_CreateChangeSet.html
+
+        def create_change_set(stack_name, options = {})
+          params = {
+            'StackName' => stack_name,
+          }
+
+          if options['ChangeSetName']
+            params['ChangeSetName'] = options['ChangeSetName']
+          end
+
+          if options['Description']
+            params['Description'] = options['Description']
+          end
+          if options['UsePreviousTemplate']
+            params['UsePreviousTemplate'] = options['UsePreviousTemplate']
+          end
+
+          if options['NotificationARNs']
+            params.merge!(Fog::AWS.indexed_param("NotificationARNs.member", [*options['NotificationARNs']]))
+          end
+
+          if options['Parameters']
+            options['Parameters'].keys.each_with_index do |key, index|
+              index += 1 # params are 1-indexed
+              params.merge!({
+                "Parameters.member.#{index}.ParameterKey"   => key,
+                "Parameters.member.#{index}.ParameterValue" => options['Parameters'][key]
+              })
+            end
+          end
+
+          if options['TemplateBody']
+            params['TemplateBody'] = options['TemplateBody']
+          elsif options['TemplateURL']
+            params['TemplateURL'] = options['TemplateURL']
+          end
+
+          request({
+            'Action'    => 'CreateChangeSet',
+            :parser     => Fog::Parsers::AWS::CloudFormation::CreateChangeSet.new
+          }.merge!(params))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/create_stack.rb
+++ b/lib/fog/aws/requests/cloud_formation/create_stack.rb
@@ -16,6 +16,9 @@ module Fog
         #   * Parameters [Hash] Hash of providers to supply to template
         #   * TimeoutInMinutes [Integer] Minutes to wait before status is set to CREATE_FAILED
         #   * Capabilities [Array] List of capabilties the stack is granted. Currently CAPABILITY_IAM for allowing the creation of IAM resources
+        #   * StackPolicyBody [String] Structure containing the stack policy body.
+        #   * StackPolicyURL [String] URL of file containing the stack policy.
+        #   * Tags [Array] Key-value pairs to associate with this stack.
         #
         # @return [Excon::Response]:
         #   * body [Hash:
@@ -67,6 +70,12 @@ module Fog
             params['TemplateBody'] = options['TemplateBody']
           elsif options['TemplateURL']
             params['TemplateURL'] = options['TemplateURL']
+          end
+
+          if options['StackPolicyBody']
+            params['StackPolicyBody'] = options['StackPolicyBody']
+          elsif options['StackPolicyURL']
+            params['StackPolicyURL'] = options['StackPolicyURL']
           end
 
           if options['TimeoutInMinutes']

--- a/lib/fog/aws/requests/cloud_formation/delete_change_set.rb
+++ b/lib/fog/aws/requests/cloud_formation/delete_change_set.rb
@@ -1,0 +1,26 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/basic'
+
+        # Delete a change set.
+        #
+        # @param ChangeSetName [String] The name of the change set to delete.
+        # @option options StackName [String] The Stack name or ID (ARN) that is associated with change set.
+        #
+        # @return [Excon::Response]
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_DeleteChangeSet.html
+
+        def delete_change_set(change_set_name, options = {})
+          options['ChangeSetName'] = change_set_name
+          request({
+            'Action'    => 'DeleteChangeSet',
+            :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
+          }.merge!(options))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/describe_account_limits.rb
+++ b/lib/fog/aws/requests/cloud_formation/describe_account_limits.rb
@@ -1,0 +1,27 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/describe_account_limits'
+
+        # Describe account_limits.
+        #
+        #
+        # @return [Excon::Response]
+        #   * body [Hash]:
+        #     * AccountLimits [Array]
+        #     * member [Hash]:
+        #       * StackLimit [Integer]
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_DescribeAccountLimits.html
+
+        def describe_account_limits()
+          request(
+            'Action' => 'DescribeAccountLimits',
+            :parser  => Fog::Parsers::AWS::CloudFormation::DescribeAccountLimits.new
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/describe_change_set.rb
+++ b/lib/fog/aws/requests/cloud_formation/describe_change_set.rb
@@ -1,0 +1,43 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/describe_change_set'
+
+        # Describe change_set.
+        #
+        # * ChangeSetName [String] The name of the change set to describe.
+        # @param options [Hash]
+        # @option options StackName [String] Name of the stack for the change set.
+        #
+        # @return [Excon::Response]
+        #   * body [Hash]:
+        #         * ChangeSetId [String] -
+        #         * ChangeSetName [String] -
+        #         * Description [String] -
+        #         * CreationTime [Time] -
+        #         * ExecutionStatus [String] -
+        #         * StackId [String] -
+        #         * StackName [String] -
+        #         * Status [String] -
+        #         * StackReason [String] -
+        #         * NotificationARNs [Array] -
+        #           * NotificationARN [String] -
+        #         * Parameters [Array] -
+        #           * parameter [Hash]:
+        #             * ParameterKey [String] -
+        #             * ParameterValue [String] -
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_DescribeChangeSet.html
+
+        def describe_change_set(change_set_name, options = {})
+          options['ChangeSetName'] = change_set_name
+          request({
+            'Action'    => 'DescribeChangeSet',
+            :parser     => Fog::Parsers::AWS::CloudFormation::DescribeChangeSet.new
+          }.merge!(options))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/describe_stack_resource.rb
+++ b/lib/fog/aws/requests/cloud_formation/describe_stack_resource.rb
@@ -1,0 +1,40 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/describe_stack_resource'
+
+        # Describe stack resource.
+        #
+        # @param options Hash]:
+        #   * LogicalResourceId [String] Logical name of the resource as specified in the template
+        #   * StackName [String] The name or the unique stack ID
+        #
+        # @return [Excon::Response]
+        #   * body [Hash]:
+        #     * StackResourceDetail [Hash] - Matching resources
+        #         *Description [String] -
+        #         * LastUpdatedTimestamp [Timestamp] -
+        #         * LogicalResourceId [String] -
+        #         * Metadata [String] -
+        #         * PhysicalResourceId [String] -
+        #         * ResourceStatus [String] -
+        #         * ResourceStatusReason [String] -
+        #         * ResourceType [String] -
+        #         * StackId [String] -
+        #         * StackName [String] -
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_DescribeStackResource.html
+
+        def describe_stack_resource(logical_resource_id, stack_name )
+          request(
+            'Action'    => 'DescribeStackResource',
+            'LogicalResourceId' => logical_resource_id,
+            'StackName' => stack_name,
+            :parser     => Fog::Parsers::AWS::CloudFormation::DescribeStackResource.new
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/estimate_template_cost.rb
+++ b/lib/fog/aws/requests/cloud_formation/estimate_template_cost.rb
@@ -1,0 +1,48 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/estimate_template_cost'
+
+        # Returns the estimated monthly cost of a template.
+        #
+        # * options [Hash]:
+        #   * TemplateBody [String] Structure containing the template body.
+        #   or (one of the two Template parameters is required)
+        #   * TemplateURL [String] URL of file containing the template body.
+        #   * Parameters [Hash] Hash of providers to supply to template
+        #
+        # @return [Excon::Response]:
+        #   * body [Hash:
+        #     * Url [String] - An AWS Simple Monthly Calculator URL with a query string that describes the resources required to run the template.
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_EstimateTemplateCost.html
+
+        def estimate_template_cost(options = {})
+          params = {}
+
+          if options['Parameters']
+            options['Parameters'].keys.each_with_index do |key, index|
+              index += 1 # params are 1-indexed
+              params.merge!({
+                "Parameters.member.#{index}.ParameterKey"   => key,
+                "Parameters.member.#{index}.ParameterValue" => options['Parameters'][key]
+              })
+            end
+          end
+
+          if options['TemplateBody']
+            params['TemplateBody'] = options['TemplateBody']
+          elsif options['TemplateURL']
+            params['TemplateURL'] = options['TemplateURL']
+          end
+
+          request({
+            'Action'    => 'EstimateTemplateCost',
+            :parser     => Fog::Parsers::AWS::CloudFormation::EstimateTemplateCost.new
+          }.merge!(params))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/execute_change_set.rb
+++ b/lib/fog/aws/requests/cloud_formation/execute_change_set.rb
@@ -1,0 +1,26 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/basic'
+
+        # Execute a change set.
+        #
+        # @param ChangeSetName [String] The name of the change set to delete.
+        # @option options StackName [String] The Stack name or ID (ARN) that is associated with change set.
+        #
+        # @return [Excon::Response]
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_ExecuteChangeSet.html
+
+        def execute_change_set(change_set_name, options = {})
+          options['ChangeSetName'] = change_set_name
+          request({
+            'Action'    => 'ExecuteChangeSet',
+            :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
+          }.merge!(options))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/get_stack_policy.rb
+++ b/lib/fog/aws/requests/cloud_formation/get_stack_policy.rb
@@ -1,0 +1,27 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/get_stack_policy'
+
+        # Describe stacks.
+        #
+        # @param stack_name [String] The name or unique stack ID that is associated with the stack whose policy you want to get.
+        #
+        # @return [Excon::Response]
+        #   * body [Hash]:
+        #     * StackPolicyBody [String] - Structure containing the stack policy body.
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_GetStackPolicy.html
+
+        def get_stack_policy(stack_name)
+          request(
+            'Action'    => 'GetStackPolicy',
+            'StackName' => stack_name,
+            :parser     => Fog::Parsers::AWS::CloudFormation::GetStackPolicy.new
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/get_template_summary.rb
+++ b/lib/fog/aws/requests/cloud_formation/get_template_summary.rb
@@ -1,0 +1,46 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/get_template_summary'
+
+        # Returns information about a new or existing template.
+        #
+        # * options [Hash]:
+        #   * stack_name [String] Name of the stack or the stack ID.
+        #   or
+        #   * TemplateBody [String] Structure containing the template body.
+        #   or
+        #   * TemplateURL [String] URL of file containing the template body.
+        #
+        # @return [Excon::Response]:
+        #   * body [Hash:
+        #     * Capabilities [Array] List of capabilties in the template.
+        #     * CapabilitiesReason [String] The list of resources that generated the values in the Capabilities response element.
+        #     * Description [String] Template Description.
+        #     * Metadata [String] Template Metadata.
+        #     * Parameters [Array] A list of parameter declarations that describe various properties for each parameter.
+        #     * ResourceTypes [Array] all the template resource types that are defined in the template
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_GetTemplateSummary.html
+
+        def get_template_summary(options = {})
+          params = {}
+
+          if options['StackName']
+            params['StackName'] = options['StackName']
+          elsif options['TemplateBody']
+            params['TemplateBody'] = options['TemplateBody']
+          elsif options['TemplateURL']
+            params['TemplateURL'] = options['TemplateURL']
+          end
+
+          request({
+            'Action'    => 'GetTemplateSummary',
+            :parser     => Fog::Parsers::AWS::CloudFormation::GetTemplateSummary.new
+          }.merge!(params))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/list_change_sets.rb
+++ b/lib/fog/aws/requests/cloud_formation/list_change_sets.rb
@@ -1,0 +1,40 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/list_change_sets'
+
+        # List change sets.
+        #
+        # @param stack_name String] Name or the ARN of the stack for which you want to list change sets.
+        #
+        # @option options StackName [String] Name of the stack to describe.
+        #
+        # @return [Excon::Response]
+        #   * body [Hash]:
+        #     * Summaries [Array] - Matching change sets
+        #       * stack [Hash]:
+        #         * ChangeSetId [String] -
+        #         * ChangeSetName [String] -
+        #         * Description [String] -
+        #         * CreationTime [Time] -
+        #         * ExecutionStatus [String] -
+        #         * StackId [String] -
+        #         * StackName [String] -
+        #         * Status [String] -
+        #         * StackReason [String] -
+        #
+        #
+        # @see http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ListChangeSets.html
+
+        def list_change_sets(stack_name, options = {})
+          request({
+            'Action'    => 'ListChangeSets',
+            'StackName' => stack_name,
+            :parser     => Fog::Parsers::AWS::CloudFormation::ListChangeSets.new
+          }.merge!(options))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/set_stack_policy.rb
+++ b/lib/fog/aws/requests/cloud_formation/set_stack_policy.rb
@@ -1,0 +1,38 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/basic'
+
+        # Sets a stack policy for a specified stack.
+        #
+        # @param stack_name [String] Name or unique stack ID that you want to associate a policy with.
+        # * options [Hash]:
+        #   * StackPolicyBody [String] Structure containing the stack policy body.
+        #   or (one of the two StackPolicy parameters is required)
+        #   * StackPolicyURL [String] URL of file containing the stack policy.
+        #   * Parameters [Hash] Hash of providers to supply to StackPolicy
+        #
+        # @return [Excon::Response]:
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_SetStackPolicy.html
+
+        def set_stack_policy(stack_name, options = {})
+          params = {}
+
+          if options['StackPolicyBody']
+            params['StackPolicyBody'] = options['StackPolicyBody']
+          elsif options['StackPolicyURL']
+            params['StackPolicyURL'] = options['StackPolicyURL']
+          end
+
+          request({
+            'Action'    => 'SetStackPolicy',
+            'StackName' => stack_name,
+            :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
+          }.merge!(params))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cloud_formation/signal_resource.rb
+++ b/lib/fog/aws/requests/cloud_formation/signal_resource.rb
@@ -1,0 +1,32 @@
+module Fog
+  module AWS
+    class CloudFormation
+      class Real
+        require 'fog/aws/parsers/cloud_formation/basic'
+
+        # Sends a signal to the specified resource.
+        #
+        # @param options Hash]:
+        #   * LogicalResourceId [String] The logical ID of the resource that you want to signal.
+        #   * StackName [String] The stack name or unique stack ID that includes the resource that you want to signal.
+        #   * Status [String] The status of the signal, which is either success or failure.
+        #   * UniqueId [String] A unique ID of the signal.
+        #
+        # @return [Excon::Response]
+        #
+        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_SignalResource.html
+
+        def signal_resource(logical_resource_id, stack_name, status, unique_id )
+          request(
+            'Action'    => 'SignalResource',
+            'LogicalResourceId' => logical_resource_id,
+            'StackName' => stack_name,
+            'Status' => status,
+            'UniqueId' => unique_id,
+            :parser     => Fog::Parsers::AWS::CloudFormation::Basic.new
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds all the missing commands from the latest aws cloud formation including support for change sets, stack policy and other missing cloud formation calls.  This is mostly additional code it would be great if we can get this in next version.   