### PR TITLE
Add attribute is_default in vpc

### DIFF
--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -9,6 +9,7 @@ module Fog
         attribute :dhcp_options_id,  :aliases => 'dhcpOptionsId'
         attribute :tags,             :aliases => 'tagSet'
         attribute :tenancy,          :aliases => 'instanceTenancy'
+        attribute :is_default,       :aliases => 'isDefault'
 
         def initialize(attributes={})
           self.dhcp_options_id ||= "default"
@@ -19,6 +20,11 @@ module Fog
         def ready?
           requires :state
           state == 'available'
+        end
+
+        def is_default?
+          require :is_default
+          is_default
         end
 
         # Removes an existing vpc

--- a/lib/fog/aws/parsers/compute/describe_vpcs.rb
+++ b/lib/fog/aws/parsers/compute/describe_vpcs.rb
@@ -30,8 +30,10 @@ module Fog
               end
             else
               case name
-              when 'vpcId', 'state', 'cidrBlock', 'dhcpOptionsId', 'instanceTenancy', 'isDefault'
+              when 'vpcId', 'state', 'cidrBlock', 'dhcpOptionsId', 'instanceTenancy'
                 @vpc[name] = value
+              when 'isDefault'
+                @vpc['isDefault'] = value == 'true'
               when 'item'
                 @response['vpcSet'] << @vpc
                 @vpc = { 'tagSet' => {} }


### PR DESCRIPTION
Add `is_default` attribute in vpc model

We have this attribute in aws api response and we saved this attribute in response parser as a string but not with a real attribute