### PR TITLE
Correct optional parameter naming in documentation for Fog::AWS::Auto…

### DIFF
--- a/lib/fog/aws/requests/auto_scaling/put_scaling_policy.rb
+++ b/lib/fog/aws/requests/auto_scaling/put_scaling_policy.rb
@@ -23,7 +23,7 @@ module Fog
         #   Auto Scaling group size). A positive increment adds to the current
         #   capacity and a negative value removes from the current capacity.
         # * options<~Hash>:
-        #   * 'CoolDown'<~Integer> - The amount of time, in seconds, after a
+        #   * 'Cooldown'<~Integer> - The amount of time, in seconds, after a
         #     scaling activity completes before any further trigger-related
         #     scaling activities can start
         #


### PR DESCRIPTION
…scaling::Real#put_scaling_policy

Stumbled onto this when working with the put_scaling_policy method. Just correcting the documentation to match http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_PutScalingPolicy.html