### PR TITLE
fix S3 #delete_multiple_objects for UTF-8 names

### DIFF
--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -46,7 +46,7 @@ module Fog
           end
           data << "</Delete>"
 
-          headers['Content-Length'] = data.length
+          headers['Content-Length'] = data.bytesize
           headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).
                                    gsub("\n", '')
 

--- a/tests/requests/storage/object_tests.rb
+++ b/tests/requests/storage/object_tests.rb
@@ -128,6 +128,10 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].delete_multiple_objects(@directory.identity, ['fog_object', 'fog_other_object']).body
     end
 
+    tests("#delete_multiple_objects('#{@directory.identity}', 'fØg_öbjèct', UTF-8)").succeeds do
+      Fog::Storage[:aws].delete_multiple_objects(@directory.identity, ['fØg_öbjèct'])
+    end
+
   end
 
   fognonbucket = uniq_id('fognonbucket')


### PR DESCRIPTION
Hello!
I was debugging https://github.com/backup/backup/issues/670 and i found out that fog-aws' `#delete_multiple_objects` does not work with UTF-8 file names.

The problem is in the 'Content-Length' header, `String#length` is not the right method to find UTF-8 strings size:

```
> "fØg_öbjèct".length
 => 10
> "fØg_öbjèct".bytesize
 => 13
```

Please review the test, it not very clear to me if that's enough (https://github.com/fog/fog-aws/issues/311)