### PR TITLE
Add `Fog::AWS::STS.Mock#assume_role`

### DIFF
--- a/lib/fog/aws/requests/sts/assume_role.rb
+++ b/lib/fog/aws/requests/sts/assume_role.rb
@@ -39,6 +39,22 @@ module Fog
           })
         end
       end
+
+      class Mock
+        def assume_role(role_session_name, role_arn, external_id=nil, policy=nil, duration=3600)
+          Excon::Response.new.tap do |response|
+            response.status = 200
+
+            response.body = {
+              'Arn'             => role_arn,
+              'AccessKeyId'     => Fog::Mock.random_base64(20),
+              'SecretAccessKey' => Fog::Mock.random_base64(40),
+              'SessionToken'    => Fog::Mock.random_base64(580),
+              'Expiration'      => Time.now + duration,
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/aws/requests/sts/assume_role.rb
+++ b/lib/fog/aws/requests/sts/assume_role.rb
@@ -42,15 +42,17 @@ module Fog
 
       class Mock
         def assume_role(role_session_name, role_arn, external_id=nil, policy=nil, duration=3600)
+          account_id = /[0-9]{12}/.match(role_arn)
+
           Excon::Response.new.tap do |response|
             response.status = 200
 
             response.body = {
-              'Arn'             => role_arn,
+              'Arn'             => "arn:aws:sts::#{account_id}:assumed-role/#{role_session_name}/#{role_session_name}",
               'AccessKeyId'     => Fog::Mock.random_base64(20),
               'SecretAccessKey' => Fog::Mock.random_base64(40),
               'SessionToken'    => Fog::Mock.random_base64(580),
-              'Expiration'      => Time.now + duration,
+              'Expiration'      => (Time.now + duration).utc.iso8601,
             }
           end
         end

--- a/lib/fog/aws/requests/sts/assume_role.rb
+++ b/lib/fog/aws/requests/sts/assume_role.rb
@@ -43,6 +43,7 @@ module Fog
       class Mock
         def assume_role(role_session_name, role_arn, external_id=nil, policy=nil, duration=3600)
           account_id = /[0-9]{12}/.match(role_arn)
+          request_id = Fog::AWS::Mock.request_id
 
           Excon::Response.new.tap do |response|
             response.status = 200
@@ -54,7 +55,11 @@ module Fog
               'SecretAccessKey' => Fog::Mock.random_base64(40),
               'SessionToken'    => Fog::Mock.random_base64(580),
               'Expiration'      => (Time.now + duration).utc.iso8601,
-              'RequestId'       => Fog::AWS::Mock.request_id
+              'RequestId'       => request_id,
+            }
+
+            response.headers = {
+              'x-amzn-RequestId' => request_id,
             }
           end
         end

--- a/lib/fog/aws/requests/sts/assume_role.rb
+++ b/lib/fog/aws/requests/sts/assume_role.rb
@@ -49,10 +49,12 @@ module Fog
 
             response.body = {
               'Arn'             => "arn:aws:sts::#{account_id}:assumed-role/#{role_session_name}/#{role_session_name}",
+              'AssumedRoleId'   => "#{Fog::Mock.random_base64(21)}:#{role_session_name}",
               'AccessKeyId'     => Fog::Mock.random_base64(20),
               'SecretAccessKey' => Fog::Mock.random_base64(40),
               'SessionToken'    => Fog::Mock.random_base64(580),
               'Expiration'      => (Time.now + duration).utc.iso8601,
+              'RequestId'       => Fog::AWS::Mock.request_id
             }
           end
         end


### PR DESCRIPTION
Add `Fog::AWS::STS.Mock#assume_role`. The method returns a `Excon::Response` instance mocking the following fields:

* `Arn`
* `AssumedRoleId`   
* `AccessKeyId`     
* `SecretAccessKey` 
* `SessionToken`    
* `Expiration`     
* `RequestId` 