### PR TITLE
Fix warnings in running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,5 @@ notifications:
 env:
   global:
     secure: LlDKdKSRo3sEjQ55XesbOXhKZ3RrOtqoD1ZL8Wx39K3iVzeEV3Kc8HjDfEvo7R4pOc3BMTNJcputklVEPN0FkWGN7Py+OEtbHj3IZl0MX+KEWNk0gU+4+sgPrL1eXUQyMUSkCrBsKg08rPel4KMYUOXbtnLyUU9PDbBwm4LJYOc=
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,8 @@ group :test, :default do
   gem 'pry-nav'
   gem 'mime-types', '~> 3.1'
 end
-gem "codeclimate-test-reporter", group: :test, require: nil
+
+group :test do
+  gem "simplecov"
+  gem "codeclimate-test-reporter", "~> 1.0.0"
+end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,6 +1,7 @@
 begin
   require 'simplecov'
   SimpleCov.start
+  SimpleCov.command_name "Shindo"
 rescue LoadError => e
   $stderr.puts "not recording test coverage: #{e.inspect}"
 end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,6 +1,6 @@
 begin
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require 'simplecov'
+  SimpleCov.start
 rescue LoadError => e
   $stderr.puts "not recording test coverage: #{e.inspect}"
 end


### PR DESCRIPTION
# About the bugs
Running the tests by `bundle exec shindo tests/requests/sqs` and it shows two warnings.
First is
```
W, [2016-11-19T12:08:19.789039 #2878]  WARN -- :
This usage of the Code Climate Test Reporter is now deprecated. Since version
1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
run the provided `codeclimate-test-reporter` binary separately to report your
results to Code Climate.
```
The second one is
```
SimpleCov failed to recognize the test framework and/or suite used. Please specify manually using SimpleCov.command_name 'Unit Tests'.
```

# How to fix
## The first warning
 I follow the usage mentioned in [ruby-test-reporter Upgrading from pre-1.0 Versions](https://github.com/codeclimate/ruby-test-reporter#upgrading-from-pre-10-versions)

I execute `bundle exec shined tests/` again and confirm the warning doesn't show up.

## The second warning
I add the line `SimpleCov.command_name "Shindo"` seeing [simplecov giving test-suite-name](https://github.com/colszowka/simplecov#test-suite-names).
I don't follow the way like `'test:units'` mentioned in README.md, , referring to `#guess` in `lib/simplecov/command_guesser.rb`.
This is implemented like

```ruby
def guess
  from_env || from_command_line_options || from_defined_constants
end
```
`#from_command_line_options` checks the path of test-suites and judges the test framework and returns nothing when the path doesn't match; `#from_defined_constants` checks a name of test frameworks and returns 'Unknown Test Framework' when the name doesn't match.
I think it's reasonable to pass 'Shindo' instead of a path.

I also confirm the warning doesn't show up.


# Test
I run tests by `bundle exec shindo tests/requests/sqs`(I would like to add a feature to sqs).
All tests green and the two warnings don't show.
