### PR TITLE
Add creation date and enhanced networking support for images

### DIFF
--- a/lib/fog/aws/models/compute/image.rb
+++ b/lib/fog/aws/models/compute/image.rb
@@ -23,6 +23,7 @@ module Fog
         attribute :name
         attribute :virtualization_type,   :aliases => 'virtualizationType'
         attribute :creation_date,         :aliases => 'creationDate'
+        attribute :ena_support,           :aliases => 'enaSupport'
 
         def deregister(delete_snapshot = false)
           service.deregister_image(id)

--- a/lib/fog/aws/models/compute/image.rb
+++ b/lib/fog/aws/models/compute/image.rb
@@ -22,6 +22,7 @@ module Fog
         attribute :tags,                  :aliases => 'tagSet'
         attribute :name
         attribute :virtualization_type,   :aliases => 'virtualizationType'
+        attribute :creation_date,         :aliases => 'creationDate'
 
         def deregister(delete_snapshot = false)
           service.deregister_image(id)

--- a/lib/fog/aws/models/compute/images.rb
+++ b/lib/fog/aws/models/compute/images.rb
@@ -32,7 +32,8 @@ module Fog
         #    ramdisk_id=nil,
         #    root_device_type=nil,
         #    root_device_name=nil,
-        #    tags=nil
+        #    tags=nil,
+        #    creation_date=nil
         #  >
         #
 

--- a/lib/fog/aws/models/compute/images.rb
+++ b/lib/fog/aws/models/compute/images.rb
@@ -33,7 +33,8 @@ module Fog
         #    root_device_type=nil,
         #    root_device_name=nil,
         #    tags=nil,
-        #    creation_date=nil
+        #    creation_date=nil,
+        #    ena_support=nil
         #  >
         #
 

--- a/lib/fog/aws/parsers/compute/describe_images.rb
+++ b/lib/fog/aws/parsers/compute/describe_images.rb
@@ -66,14 +66,16 @@ module Fog
               end
             else
               case name
-              when 'architecture', 'description', 'hypervisor', 'imageId', 'imageLocation', 'imageOwnerAlias', 'imageOwnerId', 'imageState', 'imageType', 'kernelId', 'name', 'platform', 'ramdiskId', 'rootDeviceType','rootDeviceName','virtualizationType','creationDate'
+              when 'architecture', 'description', 'hypervisor', 'imageId', 'imageLocation', 'imageOwnerAlias', 'imageOwnerId', 'imageState', 'imageType', 'kernelId', 'name', 'platform', 'ramdiskId', 'rootDeviceType','rootDeviceName','virtualizationType'
                 @image[name] = value
-              when 'isPublic' or 'enaSupport'
+              when 'isPublic','enaSupport'
                 if value == 'true'
                   @image[name] = true
                 else
                   @image[name] = false
                 end
+              when 'creationDate'
+                @image[name] = Time.parse(value)
               when 'item'
                 @response['imagesSet'] << @image
                 @image = { 'blockDeviceMapping' => [], 'productCodes' => [], 'stateReason' => {}, 'tagSet' => {} }

--- a/lib/fog/aws/parsers/compute/describe_images.rb
+++ b/lib/fog/aws/parsers/compute/describe_images.rb
@@ -68,7 +68,7 @@ module Fog
               case name
               when 'architecture', 'description', 'hypervisor', 'imageId', 'imageLocation', 'imageOwnerAlias', 'imageOwnerId', 'imageState', 'imageType', 'kernelId', 'name', 'platform', 'ramdiskId', 'rootDeviceType','rootDeviceName','virtualizationType','creationDate'
                 @image[name] = value
-              when 'isPublic'
+              when 'isPublic' or 'enaSupport'
                 if value == 'true'
                   @image[name] = true
                 else

--- a/lib/fog/aws/parsers/compute/describe_images.rb
+++ b/lib/fog/aws/parsers/compute/describe_images.rb
@@ -66,7 +66,7 @@ module Fog
               end
             else
               case name
-              when 'architecture', 'description', 'hypervisor', 'imageId', 'imageLocation', 'imageOwnerAlias', 'imageOwnerId', 'imageState', 'imageType', 'kernelId', 'name', 'platform', 'ramdiskId', 'rootDeviceType','rootDeviceName','virtualizationType'
+              when 'architecture', 'description', 'hypervisor', 'imageId', 'imageLocation', 'imageOwnerAlias', 'imageOwnerId', 'imageState', 'imageType', 'kernelId', 'name', 'platform', 'ramdiskId', 'rootDeviceType','rootDeviceName','virtualizationType','creationDate'
                 @image[name] = value
               when 'isPublic'
                 if value == 'true'

--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -36,6 +36,7 @@ module Fog
         #       * 'rootDeviceName'<~String> - Root device name, e.g. /dev/sda1
         #       * 'rootDeviceType'<~String> - Root device type, ebs or instance-store
         #       * 'virtualizationType'<~String> - Type of virtualization
+        #       * 'creationDate'<~Date> - Date the image was created
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html]
         def describe_images(filters = {})

--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -37,6 +37,7 @@ module Fog
         #       * 'rootDeviceType'<~String> - Root device type, ebs or instance-store
         #       * 'virtualizationType'<~String> - Type of virtualization
         #       * 'creationDate'<~Date> - Date the image was created
+        #       * 'enaSupport'<~Boolean> - whether or not the image supports enhanced networking
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html]
         def describe_images(filters = {})

--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -36,7 +36,7 @@ module Fog
         #       * 'rootDeviceName'<~String> - Root device name, e.g. /dev/sda1
         #       * 'rootDeviceType'<~String> - Root device type, ebs or instance-store
         #       * 'virtualizationType'<~String> - Type of virtualization
-        #       * 'creationDate'<~Date> - Date the image was created
+        #       * 'creationDate'time<~Datetime> - Date and time the image was created
         #       * 'enaSupport'<~Boolean> - whether or not the image supports enhanced networking
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html]

--- a/tests/requests/compute/image_tests.rb
+++ b/tests/requests/compute/image_tests.rb
@@ -21,7 +21,9 @@ Shindo.tests('Fog::Compute[:aws] | image requests', ['aws']) do
       'rootDeviceType'      => String,
       'stateReason'         => {},
       'tagSet'              => {},
-      'virtualizationType'  => String
+      'virtualizationType'  => String,
+      'creationDate' => Fog::Nullable::Time,
+      'enaSupport' => Fog::Nullable::Boolean
     }],
     'requestId'     => String,
   }


### PR DESCRIPTION
Have added creationDate and enaSupport members to image so as to know the images created date and if they support enhanced networking.

See: 
* http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Image.html
* http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
* https://github.com/fog/fog-aws/blob/7e5e6ff/lib/fog/aws/parsers/compute/describe_images.rb

Fixes: https://github.com/fog/fog-aws/issues/320