### PR TITLE
Fix the bug that can't create fifo queue in SQS.

### DIFF
--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -128,7 +128,7 @@ module Fog
               :host               => @host,
               :path               => path || @path,
               :port               => @port,
-              :version            => '2009-02-01'
+              :version            => '2012-11-05'
             }
           )
 


### PR DESCRIPTION
# About the bug
Trying to create FIFO queue following [the document](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html), the error occurs (ommited some lines):
```
/path/to/vendor/bundle/ruby/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/expects.rb:7:in `response_call': Expected(200) <=> Actual(400 Bad Request) (Excon::Error::BadRequest)

InvalidParameterValue Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length
```

The script is
```ruby
require 'fog/aws'

sqs = Fog::AWS::SQS.new region: "us-west-2"
sqs.create_queue(name="FifoQueue.fifo", {"Attribute.1.Name" => "FifoQueue" , "Attribute.1.Value" => "true"})
```

# How to fix
The error says a queue name can't include '.' but fifo queue needs the '.fifo' suffix.
The version of query api fog-awe uses in SQS is behind from the latest and doesn't support the fifo queue (or more exactly, the old version doesn't support a queue name including '.', which doesn't necessarily mean whether it supports FIFO queue).
I changed the version from `2009-02-01` into `2012-11-05`, and the error doesn't show up.

# Testing
Executed `bundle exec shindo tests/requests/sqs`. Results are all green.
