### PR TITLE
credential_fetcher: Mark AWS metadata calls as idempotent

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -21,15 +21,15 @@ module Fog
               if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
                 connection = options[:connection] || Excon.new(CONTAINER_CREDENTIALS_HOST)
                 credential_path = options[:credential_path] || ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
-                role_data = connection.get(:path => credential_path, :expects => 200).body
+                role_data = connection.get(:path => credential_path, :idempotent => true, :expects => 200).body
 
                 connection = options[:metadata_connection] || Excon.new(INSTANCE_METADATA_HOST)
-                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :expects => 200).body
+                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body
               else
                 connection = options[:connection] || Excon.new(INSTANCE_METADATA_HOST)
-                role_name = connection.get(:path => INSTANCE_METADATA_PATH, :expects => 200).body
-                role_data = connection.get(:path => INSTANCE_METADATA_PATH+role_name, :expects => 200).body
-                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :expects => 200).body
+                role_name = connection.get(:path => INSTANCE_METADATA_PATH, :idempotent => true, :expects => 200).body
+                role_data = connection.get(:path => INSTANCE_METADATA_PATH+role_name, :idempotent => true, :expects => 200).body
+                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body
               end
 
               region = az_data[0..-2] # get region from az


### PR DESCRIPTION
We would like to handle temporary issues with credential retrieval from AWS metadata server (usually running at 169.254.169.254) in a bit more resilient way. One possibility to achieve this is to mark the calls as idempotent, which means excon will retry them up to 3 times.

We are proposing the changes to the code in this PR. Please let us know if you have any comments or suggestions for improvement. 