### PR TITLE
Added support for attaching auto scaling groups to target groups

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -12,6 +12,7 @@ module Fog
 
       request_path 'fog/aws/requests/auto_scaling'
       request :attach_load_balancers
+      request :attach_load_balancer_target_groups
       request :create_auto_scaling_group
       request :create_launch_configuration
       request :create_or_update_tags
@@ -35,6 +36,7 @@ module Fog
       request :describe_tags
       request :describe_termination_policy_types
       request :detach_load_balancers
+      request :detach_load_balancer_target_groups
       request :detach_instances
       request :attach_instances
       request :disable_metrics_collection

--- a/lib/fog/aws/models/auto_scaling/group.rb
+++ b/lib/fog/aws/models/auto_scaling/group.rb
@@ -75,6 +75,18 @@ module Fog
           reload
         end
 
+        def attach_load_balancer_target_groups(*target_group_arns)
+          requires :id
+          service.attach_load_balancer_target_groups(id, 'TargetGroupARNs' => target_group_arns)
+          reload
+        end
+
+        def detach_load_balancer_target_groups(*target_group_arns)
+          requires :id
+          service.detach_load_balancer_target_groups(id, 'TargetGroupARNs' => target_group_arns)
+          reload
+        end
+
         def disable_metrics_collection(metrics = {})
           requires :id
           service.disable_metrics_collection(id, 'Metrics' => metrics)

--- a/lib/fog/aws/requests/auto_scaling/attach_load_balancer_target_groups.rb
+++ b/lib/fog/aws/requests/auto_scaling/attach_load_balancer_target_groups.rb
@@ -1,0 +1,58 @@
+module Fog
+  module AWS
+    class AutoScaling
+      class Real
+        require 'fog/aws/parsers/auto_scaling/basic'
+
+        # Attaches one or more load balancer target groups to the specified Auto Scaling
+        # group.
+        #
+        # ==== Parameters
+        # * auto_scaling_group_name<~String> - The name of the Auto Scaling
+        # group.
+        # * options<~Hash>:
+        # 'TagetGroupARNs'<~Array> - A list of target group arns to use.
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_AttachLoadBalancerTargetGroups.html
+        #
+
+        ExpectedOptions[:attach_load_balancer_target_groups] = %w[TargetGroupARNs]
+
+        def attach_load_balancer_target_groups(auto_scaling_group_name, options = {})
+          if target_group_arns = options.delete('TargetGroupARNs')
+            options.merge!(AWS.indexed_param('TargetGroupARNs.member.%d', *target_group_arns))
+          end
+
+          request({
+            'Action'               => 'AttachLoadBalancerTargetGroups',
+            'AutoScalingGroupName' => auto_scaling_group_name,
+            :parser                => Fog::Parsers::AWS::AutoScaling::Basic.new
+          }.merge!(options))
+        end
+
+      end
+
+      class Mock
+        def attach_load_balancer_target_groups(auto_scaling_group_name, options = {})
+          unexpected_options = options.keys - ExpectedOptions[:attach_load_balancer_target_groups]
+
+          unless unexpected_options.empty?
+            raise Fog::AWS::AutoScaling::ValidationError.new("Options #{unexpected_options.join(',')} should not be included in request")
+          end
+
+          unless self.data[:auto_scaling_groups].key?(auto_scaling_group_name)
+            raise Fog::AWS::AutoScaling::ValidationError.new('AutoScalingGroup name not found - null')
+          end
+
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'ResponseMetadata' => { 'RequestId' => Fog::AWS::Mock.request_id }
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/auto_scaling/detach_load_balancer_target_groups.rb
+++ b/lib/fog/aws/requests/auto_scaling/detach_load_balancer_target_groups.rb
@@ -1,0 +1,57 @@
+module Fog
+  module AWS
+    class AutoScaling
+      class Real
+        require 'fog/aws/parsers/auto_scaling/basic'
+
+        # Removes one or more load balancer target groups from the specified
+        # Auto Scaling group.
+        #
+        # ==== Parameters
+        # * auto_scaling_group_name<~String> - The name of the Auto Scaling
+        # group.
+        # * options<~Hash>:
+        # 'TargetGroupARNs'<~Array> - A list of target groups to detach.
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_DetachLoadBalancerTargetGroups.html
+        #
+
+        ExpectedOptions[:detach_load_balancer_target_groups] = %w[TargetGroupARNs]
+
+        def detach_load_balancer_target_groups(auto_scaling_group_name, options = {})
+          if target_group_arns = options.delete('TargetGroupARNs')
+            options.merge!(AWS.indexed_param('TargetGroupARNs.member.%d', *target_group_arns))
+          end
+
+          request({
+            'Action'               => 'DetachLoadBalancerTargetGroups',
+            'AutoScalingGroupName' => auto_scaling_group_name,
+            :parser                => Fog::Parsers::AWS::AutoScaling::Basic.new
+          }.merge!(options))
+        end
+      end
+
+      class Mock
+        def detach_load_balancer_target_groups(auto_scaling_group_name, options = {})
+          unexpected_options = options.keys - ExpectedOptions[:detach_load_balancer_target_groups]
+
+          unless unexpected_options.empty?
+            raise Fog::AWS::AutoScaling::ValidationError.new("Options #{unexpected_options.join(',')} should not be included in request")
+          end
+
+          unless self.data[:auto_scaling_groups].key?(auto_scaling_group_name)
+            raise Fog::AWS::AutoScaling::ValidationError.new('AutoScalingGroup name not found - null')
+          end
+
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'ResponseMetadata' => { 'RequestId' => Fog::AWS::Mock.request_id }
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/tests/requests/auto_scaling/auto_scaling_tests.rb
+++ b/tests/requests/auto_scaling/auto_scaling_tests.rb
@@ -35,6 +35,14 @@ Shindo.tests('AWS::AutoScaling | auto_scaling_tests', ['aws', 'auto_scaling']) d
       Fog::AWS[:auto_scaling].detach_load_balancers(@asg_name, 'LoadBalancerNames' => 'elb-test-fog').body
     end
 
+    tests("#attach_load_balancer_target_groups").formats(AWS::AutoScaling::Formats::BASIC) do
+      Fog::AWS[:auto_scaling].attach_load_balancer_target_groups(@asg_name, 'TargetGroupARNs' => 'elb-test-fog').body
+    end
+
+    tests("#detach_load_balancer_target_groups").formats(AWS::AutoScaling::Formats::BASIC) do
+      Fog::AWS[:auto_scaling].detach_load_balancer_target_groups(@asg_name, 'TargetGroupARNs' => 'elb-test-fog').body
+    end
+
     tests("#detach_instances").formats(AWS::AutoScaling::Formats::BASIC) do
       Fog::AWS[:auto_scaling].detach_instances(@asg_name, 'InstanceIds' => 'i-deadbeef').body
     end


### PR DESCRIPTION
This is in reference to https://github.com/fog/fog-aws/issues/328
Unfortunately I will not have time to implement support for managing
the actual ALBs and all that is reated to them.