### PR TITLE
Updated ELB Dual Stack hosted zone DNS records

### DIFF
--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -29,17 +29,25 @@ module Fog
       end
 
       # See https://forums.aws.amazon.com/message.jspa?messageID=612414
+      # Note: Oddly, to update this list, I have had to revert to going to
+      #       dev console at https://console.aws.amazon.com/route53/home, then using
+      #       search all sources for Z14GRHDCWA56QT to find this in a HashMap
       def self.elb_dualstack_hosted_zone_mapping
         @elb_dualstack_hosted_zone_mapping ||= {
           "ap-northeast-1" => "Z14GRHDCWA56QT",
+          "ap-northeast-2" => "ZWKZPGTI48KDX",
+          "ap-south-1" => "ZP97RAFLXTNZK",
           "ap-southeast-1" => "Z1LMS91P8CMLE5",
           "ap-southeast-2" => "Z1GM3OXH4ZPM65",
-          "eu-central-1"   => "Z215JYRZR1TBD5",
-          "eu-west-1"      => "Z32O12XQLNTSW2",
-          "sa-east-1"      => "Z2P70J7HTTTPLU",
-          "us-east-1"      => "Z35SXDOTRQ7X7K",
-          "us-west-1"      => "Z368ELLRRE2KJ0",
-          "us-west-2"      => "Z1H1FL5HABSF5",
+          "ca-central-1" => "ZQSVJUPU6J1EY",
+          "eu-central-1" => "Z215JYRZR1TBD5",
+          "eu-west-1" => "Z32O12XQLNTSW2",
+          "eu-west-2" => "ZHURV8PSTC4K8",
+          "us-east-1" => "Z35SXDOTRQ7X7K",
+          "us-east-2" => "Z3AADJGX6KTTL2",
+          "us-west-1" => "Z368ELLRRE2KJ0",
+          "us-west-2" => "Z1H1FL5HABSF5",
+          "sa-east-1" => "Z2P70J7HTTTPLU",
         }
       end
 


### PR DESCRIPTION
There are many new regions, this is the complete list as of today.  Very annoying that we should have to maintain this arbitrary mapping, and annoying that Amazon states in their docs it is auto-assigned in the AWS console yet not in the API.