### PR TITLE
Fix parsing of the Reserved Instance 'recurringCharge' field and add 'scope' field

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
@@ -25,7 +25,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'availabilityZone', 'instanceTenancy', 'instanceType', 'offeringType', 'productDescription', 'reservedInstancesId', 'state'
+            when 'availabilityZone', 'instanceTenancy', 'instanceType', 'offeringType', 'productDescription', 'reservedInstancesId', 'scope', 'state'
               @reserved_instance[name] = value
             when 'duration', 'instanceCount'
               @reserved_instance[name] = value.to_i

--- a/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
@@ -4,16 +4,15 @@ module Fog
       module AWS
         class DescribeReservedInstances < Fog::Parsers::Base
           def get_default_item
-            {'tagSet' => {}, 'recurringCharges' => {}}
+            {'tagSet' => {}, 'recurringCharges' => []}
           end
 
           def reset
             @context = []
-            # Note:  <recurringCharges> should also be handled as a set, but do not want to disrupt anyone relying on
-            # it currently being flatted
-            @contexts = ['reservedInstancesSet', 'tagSet']
+            @contexts = ['reservedInstancesSet', 'recurringCharges', 'tagSet']
             @reserved_instance = get_default_item
             @response = { 'reservedInstancesSet' => [] }
+            @charge = {}
             @tag = {}
           end
 
@@ -26,11 +25,11 @@ module Fog
 
           def end_element(name)
             case name
-            when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state', 'offeringType', 'instanceTenancy'
+            when 'availabilityZone', 'instanceTenancy', 'instanceType', 'offeringType', 'productDescription', 'reservedInstancesId', 'state'
               @reserved_instance[name] = value
             when 'duration', 'instanceCount'
               @reserved_instance[name] = value.to_i
-            when 'fixedPrice', 'amount', 'usagePrice'
+            when 'fixedPrice', 'usagePrice'
               @reserved_instance[name] = value.to_f
             when *@contexts
               @context.pop
@@ -39,10 +38,22 @@ module Fog
               when 'reservedInstancesSet'
                 @response['reservedInstancesSet'] << @reserved_instance
                 @reserved_instance = get_default_item
+              when 'recurringCharges'
+                @reserved_instance['recurringCharges'] << { 'frequency' => @charge['frequency'], 'amount' => @charge['amount'] }
+                @charge = {}
               when 'tagSet'
                 @reserved_instance['tagSet'][@tag['key']] = @tag['value']
                 @tag = {}
               end
+            when 'amount'
+              case @context.last
+              when 'reservedInstancesSet'
+                @reserved_instance[name] = value.to_f
+              when 'recurringCharges'
+                @charge[name] = value.to_f
+              end
+            when 'frequency'
+              @charge[name] = value
             when 'key', 'value'
               @tag[name] = value
             when 'requestId'

--- a/lib/fog/aws/requests/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/requests/compute/describe_reserved_instances.rb
@@ -20,11 +20,15 @@ module Fog
         #       * 'instanceType'<~String> - type of instance
         #       * 'instanceCount'<~Integer> - number of reserved instances
         #       * 'productDescription'<~String> - reserved instance description
+        #       * 'recurringCharges'<~Array>:
+        #         * 'frequency'<~String> - frequency of a recurring charge while the reservation is active (only Hourly at this time)
+        #         * 'amount'<~Float> - recurring charge amount
         #       * 'reservedInstancesId'<~String> - id of the instance
+        #       * 'scope'<~String> - scope of the reservation (i.e. 'Availability Zone' or 'Region' - as of version 2016/11/15)
         #       * 'start'<~Time> - start time for reservation
         #       * 'state'<~String> - state of reserved instance purchase, in .[pending-payment, active, payment-failed, retired]
         #       * 'usagePrice"<~Float> - usage price of reserved instances, per hour
-        #       * 'end' - time reservation stopped being applied (i.e sold or canceled - as of version 2013/10/01)
+        #       * 'end'<~Time> - time reservation stopped being applied (i.e. sold or canceled - as of version 2013/10/01)
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeReservedInstances.html]
         def describe_reserved_instances(filters = {})


### PR DESCRIPTION
To get access to the new Region reserved instances, I needed to add 'scope' to the parser, and specify a newer API version when creating the AWS connection, i.e.

```
AWS = Fog::Compute.new({
  provider: 'AWS',
  version: '2016-11-15',
  ...
})
```