### PR TITLE
Pin nokogiri gem for Ruby 1.9 and Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - rvm: 1.9.3
     gemfile: gemfiles/Gemfile-ruby-1.9
   - rvm: 2.0.0
-    gemfile: Gemfile
+    gemfile: gemfiles/Gemfile-ruby-2.0
   - rvm: 2.1.0
     gemfile: Gemfile
   - rvm: 2.1.1

--- a/gemfiles/Gemfile-ruby-1.9
+++ b/gemfiles/Gemfile-ruby-1.9
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem 'json', '~> 1.8'
 gem 'mime-types', '~> 2.6', '>= 2.6.2'
+gem 'nokogiri', '~> 1.6.8'
 
 gemspec :path => "../"

--- a/gemfiles/Gemfile-ruby-2.0
+++ b/gemfiles/Gemfile-ruby-2.0
@@ -1,0 +1,7 @@
+
+source "https://rubygems.org"
+
+gem 'mime-types', '~> 3.1'
+gem 'nokogiri', '~> 1.6.8'
+
+gemspec :path => "../"


### PR DESCRIPTION
Nokogiri >= 1.7 requires Ruby 2.1 or higher.