### PR TITLE
Fog mock accuracy, fixes #341

### DIFF
--- a/lib/fog/aws/requests/storage/delete_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_policy.rb
@@ -33,7 +33,6 @@ module Fog
              end
            else
              raise(Excon::Errors.status_error({:expects => 200}, response))
-             # raise Fog::AWS::IAM::NotFound.new("The bucket with name #{bucket_name} cannot be found.")
            end
         end
       end

--- a/lib/fog/aws/requests/storage/delete_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_policy.rb
@@ -32,7 +32,8 @@ module Fog
                response.status = 200
              end
            else
-             raise Fog::AWS::IAM::NotFound.new("The bucket with name #{bucket_name} cannot be found.")
+             raise(Excon::Errors.status_error({:expects => 200}, response))
+             # raise Fog::AWS::IAM::NotFound.new("The bucket with name #{bucket_name} cannot be found.")
            end
         end
       end

--- a/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
@@ -85,6 +85,7 @@ module Fog
                 'HostId' => Fog::Mock.random_base64(65)
               }
             }
+            raise(Excon::Errors.status_error({:expects => 200}, response))
 
           # Valid case.
           # TODO: (nirvdrum 12/15/11) It's not clear to me how to actually use version-id-marker, so I didn't implement it below.

--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -86,12 +86,16 @@ module Fog
             if (object && !object[:delete_marker])
               if options['If-Match'] && options['If-Match'] != object['ETag']
                 response.status = 412
+                raise(Excon::Errors.status_error({:expects => 200}, response))
               elsif options['If-Modified-Since'] && options['If-Modified-Since'] >= Time.parse(object['Last-Modified'])
                 response.status = 304
+                raise(Excon::Errors.status_error({:expects => 200}, response))
               elsif options['If-None-Match'] && options['If-None-Match'] == object['ETag']
                 response.status = 304
+                raise(Excon::Errors.status_error({:expects => 200}, response))
               elsif options['If-Unmodified-Since'] && options['If-Unmodified-Since'] < Time.parse(object['Last-Modified'])
                 response.status = 412
+                raise(Excon::Errors.status_error({:expects => 200}, response))
               else
                 response.status = 200
                 for key, value in object

--- a/tests/requests/storage/object_tests.rb
+++ b/tests/requests/storage/object_tests.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-Shindo.tests('AWS::Storage | object requests', ['aws']) do
+Shindo.tests('AWS::Storage | object requests', ['aws', 's3object']) do
   @directory = Fog::Storage[:aws].directories.create(:key => 'fogobjecttests-' + Time.now.to_i.to_s(32))
   @aws_owner = Fog::Storage[:aws].get_bucket_acl(@directory.key).body['Owner']
 
@@ -42,6 +42,10 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       data
     end
 
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file) })").returns(lorem_file.read) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file.read) }).body
+    end
+
     tests("#get_object('#{@directory.identity}', 'fog_object', {'Range' => 'bytes=0-20'})").returns(lorem_file.read[0..20]) do
       Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', {'Range' => 'bytes=0-20'}).body
     end
@@ -50,8 +54,40 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', {'Range' => 'bytes=0-0'}).body
     end
 
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file.read) })").returns(lorem_file.read) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file.read) }).body
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Modified-Since' => Time.now - 60 })").returns(lorem_file.read) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Modified-Since' => Time.now - 60 }).body
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-None-Match' => 'invalid_etag' })").returns(lorem_file.read) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-None-Match' => 'invalid_etag' }).body
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Unmodified-Since' => Time.now + 60 })").returns(lorem_file.read) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Unmodified-Since' => Time.now + 60 }).body
+    end
+
     tests("#head_object('#{@directory.identity}', 'fog_object')").succeeds do
       Fog::Storage[:aws].head_object(@directory.identity, 'fog_object')
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file.read) })").succeeds do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Match' => Digest::MD5.hexdigest(lorem_file.read) })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Modified-Since' => Time.now - 60 })").succeeds do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Modified-Since' => Time.now - 60 })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-None-Match' => 'invalid_etag' })").succeeds do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-None-Match' => 'invalid_etag' })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Unmodified-Since' => Time.now + 60 })").succeeds do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Unmodified-Since' => Time.now + 60 })
     end
 
     tests("#post_object_restore('#{@directory.identity}', 'fog_object')").succeeds do
@@ -167,6 +203,42 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
     tests("#get_object('#{@directory.identity}', 'fog_non_object')").raises(Excon::Errors::NotFound) do
       Fog::Storage[:aws].get_object(@directory.identity, 'fog_non_object')
     end
+
+    Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file)
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Match' => 'invalid_etag' })").raises(Excon::Errors::PreconditionFailed) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Match' => 'invalid_etag' })
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Modified-Since' => Time.now })").raises(Excon::Errors::NotModified) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Modified-Since' => Time.now })
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-None-Match' => Digest::MD5.hexdigest(lorem_file.read) })").raises(Excon::Errors::NotModified) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-None-Match' => Digest::MD5.hexdigest(lorem_file.read) })
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', { 'If-Unmodified-Since' => Time.now - 60 })").raises(Excon::Errors::PreconditionFailed) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', { 'If-Unmodified-Since' => Time.now - 60 })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Match' => 'invalid_etag' })").raises(Excon::Errors::PreconditionFailed) do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Match' => 'invalid_etag' })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Modified-Since' => Time.now })").raises(Excon::Errors::NotModified) do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Modified-Since' => Time.now })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-None-Match' => Digest::MD5.hexdigest(lorem_file.read) })").raises(Excon::Errors::NotModified) do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-None-Match' => Digest::MD5.hexdigest(lorem_file.read) })
+    end
+
+    tests("#head_object('#{@directory.identity}', 'fog_object', { 'If-Unmodified-Since' => Time.now - 60 })").raises(Excon::Errors::PreconditionFailed) do
+      Fog::Storage[:aws].head_object(@directory.identity, 'fog_object', { 'If-Unmodified-Since' => Time.now - 60 })
+    end
+
+    Fog::Storage[:aws].delete_object(@directory.identity, 'fog_object')
 
     tests("#head_object(fognonbucket, 'fog_non_object')").raises(Excon::Errors::NotFound) do
       Fog::Storage[:aws].head_object(fognonbucket, 'fog_non_object')

--- a/tests/requests/storage/object_tests.rb
+++ b/tests/requests/storage/object_tests.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-Shindo.tests('AWS::Storage | object requests', ['aws', 's3object']) do
+Shindo.tests('AWS::Storage | object requests', ['aws']) do
   @directory = Fog::Storage[:aws].directories.create(:key => 'fogobjecttests-' + Time.now.to_i.to_s(32))
   @aws_owner = Fog::Storage[:aws].get_bucket_acl(@directory.key).body['Owner']
 

--- a/tests/requests/storage/versioning_tests.rb
+++ b/tests/requests/storage/versioning_tests.rb
@@ -20,7 +20,7 @@ def delete_bucket
   Fog::Storage[:aws].delete_bucket(@aws_bucket_name)
 end
 
-Shindo.tests('Fog::Storage[:aws] | versioning', ["aws", 'versioning']) do
+Shindo.tests('Fog::Storage[:aws] | versioning', ["aws"]) do
   tests('success') do
     tests("#put_bucket_versioning") do
       @aws_bucket_name = 'fogbuckettests-' + Fog::Mock.random_hex(16)

--- a/tests/requests/storage/versioning_tests.rb
+++ b/tests/requests/storage/versioning_tests.rb
@@ -20,7 +20,7 @@ def delete_bucket
   Fog::Storage[:aws].delete_bucket(@aws_bucket_name)
 end
 
-Shindo.tests('Fog::Storage[:aws] | versioning', ["aws"]) do
+Shindo.tests('Fog::Storage[:aws] | versioning', ["aws", 'versioning']) do
   tests('success') do
     tests("#put_bucket_versioning") do
       @aws_bucket_name = 'fogbuckettests-' + Fog::Mock.random_hex(16)
@@ -227,6 +227,10 @@ Shindo.tests('Fog::Storage[:aws] | versioning', ["aws"]) do
 
     tests("#put_bucket_versioning('#{@aws_bucket_name}', 'bad_value')").raises(Excon::Errors::BadRequest) do
       Fog::Storage[:aws].put_bucket_versioning(@aws_bucket_name, 'bad_value')
+    end
+
+    tests("#get_bucket_object_versions('#{@aws_bucket_name}', { 'version-id-marker' => 'foo' })").raises(Excon::Errors::BadRequest) do
+      Fog::Storage[:aws].get_bucket_object_versions(@aws_bucket_name, { 'version-id-marker' => 'foo' })
     end
 
     tests("#put_bucket_versioning('fognonbucket', 'Enabled')").raises(Excon::Errors::NotFound) do


### PR DESCRIPTION
## Intro
Opening this PR for some early feedback and discussion. Originally I raised the issue (#341) under my other account (@ac-astuartkregor).

## Important considerations
It occurred to me that some folks might be using the existing functionality in their tests. Therefore this PR could cause breakages if they are already reliant on the response status being set, rather than having to rescue the exception in their code.

## What's been addressed?
I have looked at the storage requests and found any instances where a mock was setting a status code but not raising an Excon::Error of the appropriate flavour. The changes made have been verified against the actual result received when Fog is not in mock mode. Extra tests have been added to verify the success and failure cases of the various requests, in particular the `get_object` and `head_object` requests.

## What's left to discuss?
I'd like to know what people feel the scope of this PR should be. For example, should other AWS mocks be examined for accuracy as well? Should mock accuracy outside of exceptions vs response status be considered?
