### PR TITLE
Skip call to instance metadata host if region is specified

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -16,7 +16,7 @@ module Fog
           if options[:use_iam_profile]
             begin
               role_data = nil
-              az_data = nil
+              region = options[:region]
 
               if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
                 connection = options[:connection] || Excon.new(CONTAINER_CREDENTIALS_HOST)
@@ -24,15 +24,13 @@ module Fog
                 role_data = connection.get(:path => credential_path, :idempotent => true, :expects => 200).body
 
                 connection = options[:metadata_connection] || Excon.new(INSTANCE_METADATA_HOST)
-                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body
+                region ||= connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body[0..-2]
               else
                 connection = options[:connection] || Excon.new(INSTANCE_METADATA_HOST)
                 role_name = connection.get(:path => INSTANCE_METADATA_PATH, :idempotent => true, :expects => 200).body
                 role_data = connection.get(:path => INSTANCE_METADATA_PATH+role_name, :idempotent => true, :expects => 200).body
-                az_data = connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body
+                region ||= connection.get(:path => INSTANCE_METADATA_AZ, :idempotent => true, :expects => 200).body[0..-2]
               end
-
-              region = az_data[0..-2] # get region from az
 
               session = Fog::JSON.decode(role_data)
               credentials = {}


### PR DESCRIPTION
Hey, thanks for the awesome work on this gem 👍 

This PR avoids an extra fetch if region is specified.

The main benefit isn't performance, but rather permissions. For containers, AWS recommends blocking the instance metadata host (with `iptables`) so containers running on Amazon ECS don't have access to the underlying EC2 instance credentials.

http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html