### PR TITLE
Add p2 instance types

### DIFF
--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -683,6 +683,36 @@ module Fog
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "p2.xlarge",
+          :name                    => "General Purpose GPU Extra Large",
+          :bits                    => 64,
+          :cores                   => 2496,
+          :ram                     => 65498,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "p2.8xlarge",
+          :name                    => "General Purpose GPU Eight Extra Large",
+          :bits                    => 64,
+          :cores                   => 19968,
+          :ram                     => 523986,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "p2.16xlarge",
+          :name                    => "General Purpose GPU Sixteen Extra Large",
+          :bits                    => 64,
+          :cores                   => 39936,
+          :ram                     => 785979,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
         }
       ]
 


### PR DESCRIPTION
This adds the [p2 instance types](https://aws.amazon.com/ec2/instance-types/p2/).  These are gpu-based, but there wasn't a key for specifying the number of GPUs, so I followed the existing pattern.