### PR TITLE
Fixed credential refresh when instance metadata host is inaccessible

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -68,7 +68,7 @@ module Fog
 
         def refresh_credentials
           if @use_iam_profile
-            new_credentials = service.fetch_credentials :use_iam_profile => @use_iam_profile
+            new_credentials = service.fetch_credentials :use_iam_profile => @use_iam_profile, :region => @region
             if new_credentials.any?
               setup_credentials new_credentials
               return true


### PR DESCRIPTION
Pass `region` to credential refresh if specified. Otherwise, Fog tries to call instance metadata host. More context in #360.