### PR TITLE
Add a top-level require that matches the gem name

### DIFF
--- a/lib/fog-aws.rb
+++ b/lib/fog-aws.rb
@@ -1,0 +1,1 @@
+require 'fog/aws'


### PR DESCRIPTION
Reduce confusion by allowing the gem to be required via a file that
matches the gem name.

References https://github.com/fog/fog/issues/3959