### PR TITLE
Fix AWS credential mocking

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -11,7 +11,7 @@ module Fog
       module ServiceMethods
         def fetch_credentials(options)
           if options[:use_iam_profile] && Fog.mocking?
-            Fog::Compute::AWS::Mock.data[:iam_role_based_creds]
+            return Fog::Compute::AWS::Mock.data[:iam_role_based_creds]
           end
           if options[:use_iam_profile]
             begin

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -2,10 +2,9 @@ Shindo.tests('AWS | credentials', ['aws']) do
   old_mock_value = Excon.defaults[:mock]
   fog_was_mocked = Fog.mocking?
   Excon.stubs.clear
-  Fog.mock!
+  Fog.unmock!
   begin
     Excon.defaults[:mock] = true
-    default_credentials = Fog::Compute::AWS.fetch_credentials({})
     Excon.stub({:method => :get, :path => "/latest/meta-data/iam/security-credentials/"}, {:status => 200, :body => 'arole'})
     Excon.stub({:method => :get, :path => "/latest/meta-data/placement/availability-zone/"}, {:status => 200, :body => 'us-west-1a'})
 
@@ -17,7 +16,6 @@ Shindo.tests('AWS | credentials', ['aws']) do
       'Expiration' => expires_at.xmlschema
     }
 
-    Fog::Compute::AWS::Mock.data[:iam_role_based_creds] = credentials
     Excon.stub({:method => :get, :path => "/latest/meta-data/iam/security-credentials/arole"}, {:status => 200, :body => Fog::JSON.encode(credentials)})
 
     tests("#fetch_credentials") do
@@ -60,16 +58,29 @@ Shindo.tests('AWS | credentials', ['aws']) do
     end
     Fog::Time.now = Time.now
 
+    default_credentials = Fog::Compute::AWS.fetch_credentials({})
     tests("#fetch_credentials when the url 404s") do
       Excon.stub({:method => :get, :path => "/latest/meta-data/iam/security-credentials/"}, {:status => 404, :body => 'not bound'})
       Excon.stub({:method => :get, :path => "/latest/meta-data/placement/availability-zone/"}, {:status => 400, :body => 'not found'})
       returns(default_credentials) {Fog::Compute::AWS.fetch_credentials(:use_iam_profile => true)}
     end
 
+    mocked_credentials = {
+      aws_access_key_id: "access-key-id",
+      aws_secret_access_key: "secret-access-key",
+      aws_session_token: "session-token",
+      aws_credentials_expire_at: Time.at(Time.now.to_i + 500).xmlschema
+    }
+    tests("#fetch_credentials when mocking") do
+      Fog.mock!
+      Fog::Compute::AWS::Mock.data[:iam_role_based_creds] = mocked_credentials
+      returns(mocked_credentials) {Fog::Compute::AWS.fetch_credentials(:use_iam_profile => true)}
+    end
+
   ensure
     ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"] = nil
     Excon.stubs.clear
     Excon.defaults[:mock] = old_mock_value
-    Fog.unmock! if !fog_was_mocked
+    Fog.mock! if fog_was_mocked
   end
 end

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -66,10 +66,10 @@ Shindo.tests('AWS | credentials', ['aws']) do
     end
 
     mocked_credentials = {
-      aws_access_key_id: "access-key-id",
-      aws_secret_access_key: "secret-access-key",
-      aws_session_token: "session-token",
-      aws_credentials_expire_at: Time.at(Time.now.to_i + 500).xmlschema
+      :aws_access_key_id => "access-key-id",
+      :aws_secret_access_key => "secret-access-key",
+      :aws_session_token => "session-token",
+      :aws_credentials_expire_at => Time.at(Time.now.to_i + 500).xmlschema
     }
     tests("#fetch_credentials when mocking") do
       Fog.mock!


### PR DESCRIPTION
The change introduced in #252 does not actually prevent HTTP requests
from being made because of a missing early return statement.