### PR TITLE
Fix Fog::Compute::AWS::Images#all

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_images.rb
+++ b/lib/fog/aws/parsers/compute/describe_images.rb
@@ -75,7 +75,7 @@ module Fog
                   @image[name] = false
                 end
               when 'creationDate'
-                @image[name] = Time.parse(value)
+                @image[name] = Time.parse(value) if value && !value.empty?
               when 'item'
                 @response['imagesSet'] << @image
                 @image = { 'blockDeviceMapping' => [], 'productCodes' => [], 'stateReason' => {}, 'tagSet' => {} }

--- a/tests/parsers/compute/describe_images_tests.rb
+++ b/tests/parsers/compute/describe_images_tests.rb
@@ -1,0 +1,33 @@
+require 'fog/xml'
+require 'fog/aws/parsers/compute/describe_images'
+
+DESCRIBE_IMAGES_RESULT = <<-EOF
+<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>180a8433-ade0-4a6c-b35b-107897579572</requestId>
+    <imagesSet>
+        <item>
+            <imageId>aki-02486376</imageId>
+            <imageLocation>ec2-public-images-eu/vmlinuz-2.6.21-2.fc8xen-ec2-v1.0.i386.aki.manifest.xml</imageLocation>
+            <imageState>available</imageState>
+            <imageOwnerId>206029621532</imageOwnerId>
+            <creationDate/>
+            <isPublic>true</isPublic>
+            <architecture>i386</architecture>
+            <imageType>kernel</imageType>
+            <imageOwnerAlias>amazon</imageOwnerAlias>
+            <rootDeviceType>instance-store</rootDeviceType>
+            <blockDeviceMapping/>
+            <virtualizationType>paravirtual</virtualizationType>
+            <hypervisor>xen</hypervisor>
+        </item>
+    </imagesSet>
+</DescribeImagesResponse>
+EOF
+
+Shindo.tests('Compute::AWS | parsers | describe_images', ['compute', 'aws', 'parser']) do
+  tests('parses the xml').formats(AWS::Compute::Formats::DESCRIBE_IMAGES) do
+    parser = Nokogiri::XML::SAX::Parser.new(Fog::Parsers::Compute::AWS::DescribeImages.new)
+    parser.parse(DESCRIBE_IMAGES_RESULT)
+    parser.document.response
+  end
+end

--- a/tests/requests/compute/helper.rb
+++ b/tests/requests/compute/helper.rb
@@ -2,9 +2,26 @@ class AWS
   module Compute
     module Formats
       BASIC = {
-        'requestId' => String,
-        'return'    => ::Fog::Boolean
+        'requestId' => String
       }
+
+      DESCRIBE_IMAGES = BASIC.merge({
+        "imagesSet" => [{
+          "imageId" => String,
+          "imageLocation" => String,
+          "imageState" => String,
+          "imageOwnerId" => String,
+          "creationDate" => Fog::Nullable::String,
+          "isPublic" => Fog::Nullable::Boolean,
+          "architecture" => String,
+          "imageType" => String,
+          "imageOwnerAlias" => String,
+          "rootDeviceType" => String,
+          "blockDeviceMapping" => Array,
+          "virtualizationType" => String,
+          "hypervisor" => String
+        }]
+      })
     end
   end
 end


### PR DESCRIPTION
Calling `Fog::Compute::AWS::Images#all` fails with the error: `Excon::Error::Socket: 25:28: FATAL: Document is empty (Nokogiri::XML::SyntaxError)`. 

This was because the parser was calling `Time.parse` on `nil` creationDate values:

```
when 'creationDate'
  @image[name] = Time.parse(value)
```

This commit ensures nil or blank `creationDate` fields are not parsed. It also adds a test for `Fog::Parsers::Compute::AWS::DescribeImages` which wasn't present before.

Fixes https://github.com/fog/fog-aws/issues/273.