### PR TITLE
Ability to save cidrBlockAssociationSet

### DIFF
--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :tenancy,          :aliases => 'instanceTenancy'
         attribute :is_default,       :aliases => 'isDefault'
         attribute :ipv_6_cidr_block_association_set,  :aliases => 'ipv6CidrBlockAssociationSet'
+        attribute :cidrBlockAssociationSet,  :aliases => 'cidrBlockAssociationSet'
         attribute :amazon_provided_ipv_6_cidr_block,  :aliases => 'amazonProvidedIpv6CidrBlock'
 
         def subnets


### PR DESCRIPTION
describe_vpcs now return Ipv6CidrBlockAssociationSet and CidrBlockAssociationSet as a list of association objects. 
This PR attempts to save both the results in ipv_6_cidr_block_association_set and cidrBlockAssociationSet attributes respectively