### PR TITLE
Fix VPC parser

### DIFF
--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -10,8 +10,11 @@ module Fog
         attribute :tags,             :aliases => 'tagSet'
         attribute :tenancy,          :aliases => 'instanceTenancy'
         attribute :is_default,       :aliases => 'isDefault'
-        attribute :ipv_6_cidr_block_association_set,  :aliases => 'ipv6CidrBlockAssociationSet'
-        attribute :amazon_provided_ipv_6_cidr_block,  :aliases => 'amazonProvidedIpv6CidrBlock'
+
+        attribute :cidr_block_association_set, :aliases => 'cidrBlockAssociationSet'
+
+        attribute :ipv_6_cidr_block_association_set, :aliases => 'ipv6CidrBlockAssociationSet'
+        attribute :amazon_provided_ipv_6_cidr_block, :aliases => 'amazonProvidedIpv6CidrBlock'
 
         def subnets
           service.subnets(:filters => {'vpcId' => self.identity}).all

--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -13,8 +13,14 @@ module Fog
 
         attribute :cidr_block_association_set, :aliases => 'cidrBlockAssociationSet'
 
-        attribute :ipv_6_cidr_block_association_set, :aliases => 'ipv6CidrBlockAssociationSet'
-        attribute :amazon_provided_ipv_6_cidr_block, :aliases => 'amazonProvidedIpv6CidrBlock'
+        attribute :ipv6_cidr_block_association_set, :aliases => 'ipv6CidrBlockAssociationSet'
+        attribute :amazon_provided_ipv6_cidr_block, :aliases => 'amazonProvidedIpv6CidrBlock'
+
+        # Backward compatibility. Please use ipv6_cidr_block_association_set
+        alias_method :ipv_6_cidr_block_association_set,  :ipv6_cidr_block_association_set
+        alias_method :ipv_6_cidr_block_association_set=, :ipv6_cidr_block_association_set=
+        alias_method :amazon_provided_ipv_6_cidr_block,  :amazon_provided_ipv6_cidr_block
+        alias_method :amazon_provided_ipv_6_cidr_block=, :amazon_provided_ipv6_cidr_block=
 
         def subnets
           service.subnets(:filters => {'vpcId' => self.identity}).all

--- a/lib/fog/aws/parsers/compute/describe_vpcs.rb
+++ b/lib/fog/aws/parsers/compute/describe_vpcs.rb
@@ -48,7 +48,7 @@ module Fog
                 @current_cidr_block[name] = value
 
               when 'vpcSet.item.cidrBlockAssociationSet.item.cidrBlockState'
-                @current_cidr_block['state'] = value.squish
+                @current_cidr_block['state'] = value.strip
 
               when 'vpcSet.item.cidrBlockAssociationSet.item'
                 @current_vpc['cidrBlockAssociationSet'] << @current_cidr_block
@@ -60,7 +60,7 @@ module Fog
                 @current_ipv6_block[name] = value
 
               when 'vpcSet.item.ipv6CidrBlockAssociationSet.item.ipv6CidrBlockState'
-                @current_ipv6_block['state'] = value.squish
+                @current_ipv6_block['state'] = value.strip
 
               when 'vpcSet.item.ipv6CidrBlockAssociationSet.item'
                 @current_vpc['ipv6CidrBlockAssociationSet'] << @current_ipv6_block

--- a/lib/fog/aws/parsers/compute/describe_vpcs.rb
+++ b/lib/fog/aws/parsers/compute/describe_vpcs.rb
@@ -48,7 +48,7 @@ module Fog
                 @current_cidr_block[name] = value
 
               when 'vpcSet.item.cidrBlockAssociationSet.item.cidrBlockState'
-                @current_cidr_block['state'] = value.strip
+                @current_cidr_block['state'] = value.squish
 
               when 'vpcSet.item.cidrBlockAssociationSet.item'
                 @current_vpc['cidrBlockAssociationSet'] << @current_cidr_block
@@ -60,7 +60,7 @@ module Fog
                 @current_ipv6_block[name] = value
 
               when 'vpcSet.item.ipv6CidrBlockAssociationSet.item.ipv6CidrBlockState'
-                @current_ipv6_block['state'] = value.strip
+                @current_ipv6_block['state'] = value.squish
 
               when 'vpcSet.item.ipv6CidrBlockAssociationSet.item'
                 @current_vpc['ipv6CidrBlockAssociationSet'] << @current_ipv6_block

--- a/lib/fog/aws/requests/compute/create_vpc.rb
+++ b/lib/fog/aws/requests/compute/create_vpc.rb
@@ -43,16 +43,18 @@ module Fog
               response.status = 200
               vpc_id = Fog::AWS::Mock.vpc_id
               vpc = {
-                'vpcId'                 => vpc_id,
-                'state'                 => 'pending',
-                'cidrBlock'             => cidrBlock,
-                'dhcpOptionsId'         => Fog::AWS::Mock.request_id,
-                'tagSet'                => {},
-                'enableDnsSupport'      => true,
-                'enableDnsHostnames'    => false,
-                'mapPublicIpOnLaunch'   => false,
-                'classicLinkEnabled'    => false,
-                'classicLinkDnsSupport' => false
+                'vpcId'                       => vpc_id,
+                'state'                       => 'pending',
+                'cidrBlock'                   => cidrBlock,
+                'dhcpOptionsId'               => Fog::AWS::Mock.request_id,
+                'tagSet'                      => {},
+                'enableDnsSupport'            => true,
+                'enableDnsHostnames'          => false,
+                'mapPublicIpOnLaunch'         => false,
+                'classicLinkEnabled'          => false,
+                'classicLinkDnsSupport'       => false,
+                'cidrBlockAssociationSet'     => [{ 'cidrBlock' => cidrBlock, 'state' => 'associated', 'associationId' => "vpc-cidr-assoc-#{vpc_id}" }],
+                'ipv6CidrBlockAssociationSet' => []
               }
               self.data[:vpcs].push(vpc)
 

--- a/tests/requests/compute/vpc_tests.rb
+++ b/tests/requests/compute/vpc_tests.rb
@@ -32,12 +32,14 @@ Shindo.tests('Fog::Compute[:aws] | vpc requests', ['aws']) do
 
   @describe_vpcs_format = {
     'vpcSet' => [{
-      'vpcId'           => String,
-      'state'           => String,
-      'cidrBlock'       => String,
-      'dhcpOptionsId'   => String,
-      'tagSet'          => Hash,
-      'instanceTenancy' => Fog::Nullable::String,
+      'vpcId'                       => String,
+      'state'                       => String,
+      'cidrBlock'                   => String,
+      'dhcpOptionsId'               => String,
+      'tagSet'                      => Hash,
+      'instanceTenancy'             => Fog::Nullable::String,
+      'cidrBlockAssociationSet'     => [{'cidrBlock'     => String, 'associationId' => String, 'state' => String}],
+      'ipv6CidrBlockAssociationSet' => [{'ipv6CidrBlock' => String, 'associationId' => String, 'state' => String}]
     }],
     'requestId' => String
   }


### PR DESCRIPTION
This PR fixes problems with VPC parser + adds `cidr_block_association_set` attribute to model.
https://github.com/fog/fog-aws/issues/379 was not sufficient – VPC list still contains duplicates with invalid status.

**NB:** `cidr_block_association_set` and `ipv_6_cidr_block_association_set` are array of hashes (currently `ipv_6_cidr_block_association_set` is a Hash)