### PR TITLE
Add ability to encrypt a copy of an unencrypted snapshot

### DIFF
--- a/lib/fog/aws/requests/compute/copy_snapshot.rb
+++ b/lib/fog/aws/requests/compute/copy_snapshot.rb
@@ -9,8 +9,8 @@ module Fog
         # ==== Parameters
         # * source_snapshot_id<~String> - Id of snapshot
         # * source_region<~String>      - Region to move it from
-        # * description<~String>        - A description for the EBS snapshot
         # * options<~Hash>:
+        #   * 'Description'<~String>    - A description for the EBS snapshot
         #   * 'Encrypted'<~Boolean>     - Specifies whether the destination snapshot should be encrypted
         #   * 'KmsKeyId'<~String>       - The full ARN of the AWS Key Management Service (AWS KMS) CMK
         #                                 to use when creating the snapshot copy.
@@ -22,16 +22,21 @@ module Fog
         #     * 'snapshotId'<~String> - id of snapshot
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CopySnapshot.html]
-        def copy_snapshot(source_snapshot_id, source_region, description = nil, options = {})
-          params = {
-            'Action'          => 'CopySnapshot',
-            'SourceSnapshotId'=> source_snapshot_id,
-            'SourceRegion'    => source_region,
-            'Description'     => description,
-            :parser       => Fog::Parsers::Compute::AWS::CopySnapshot.new
+        def copy_snapshot(source_snapshot_id, source_region, options = {})
+          # For backward compatibility. In previous versions third param was a description
+          if options.is_a?(String)
+            Fog::Logger.warning("copy_snapshot with description as a string in third param is deprecated, use hash instead: copy_snapshot('source-id', 'source-region', { 'Description' => 'some description' })")
+            options = { 'Description' => options }
+          end
+          params              = {
+            'Action'           => 'CopySnapshot',
+            'SourceSnapshotId' => source_snapshot_id,
+            'SourceRegion'     => source_region,
+            'Description'      => options['Description'],
+            :parser            => Fog::Parsers::Compute::AWS::CopySnapshot.new
           }
           params['Encrypted'] = true if options['Encrypted']
-          params['KmsKeyId'] = options['KmsKeyId'] if options['Encrypted'] && options['KmsKeyId']
+          params['KmsKeyId']  = options['KmsKeyId'] if options['Encrypted'] && options['KmsKeyId']
           request(params)
         end
       end
@@ -43,7 +48,7 @@ module Fog
         # Fog::AWS[:compute].copy_snapshot("snap-1db0a957", 'us-east-1')
         #
 
-        def copy_snapshot(source_snapshot_id, source_region, description = nil, options = {})
+        def copy_snapshot(source_snapshot_id, source_region, options = {})
           response = Excon::Response.new
           response.status = 200
           snapshot_id = Fog::AWS::Mock.snapshot_id

--- a/lib/fog/aws/requests/compute/copy_snapshot.rb
+++ b/lib/fog/aws/requests/compute/copy_snapshot.rb
@@ -9,6 +9,11 @@ module Fog
         # ==== Parameters
         # * source_snapshot_id<~String> - Id of snapshot
         # * source_region<~String>      - Region to move it from
+        # * description<~String>        - A description for the EBS snapshot
+        # * options<~Hash>:
+        #   * 'Encrypted'<~Boolean>     - Specifies whether the destination snapshot should be encrypted
+        #   * 'KmsKeyId'<~String>       - The full ARN of the AWS Key Management Service (AWS KMS) CMK
+        #                                 to use when creating the snapshot copy.
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -17,14 +22,17 @@ module Fog
         #     * 'snapshotId'<~String> - id of snapshot
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CopySnapshot.html]
-        def copy_snapshot(source_snapshot_id, source_region, description = nil)
-          request(
+        def copy_snapshot(source_snapshot_id, source_region, description = nil, options = {})
+          params = {
             'Action'          => 'CopySnapshot',
             'SourceSnapshotId'=> source_snapshot_id,
             'SourceRegion'    => source_region,
             'Description'     => description,
             :parser       => Fog::Parsers::Compute::AWS::CopySnapshot.new
-          )
+          }
+          params['Encrypted'] = true if options['Encrypted']
+          params['KmsKeyId'] = options['KmsKeyId'] if options['Encrypted'] && options['KmsKeyId']
+          request(params)
         end
       end
 
@@ -35,7 +43,7 @@ module Fog
         # Fog::AWS[:compute].copy_snapshot("snap-1db0a957", 'us-east-1')
         #
 
-        def copy_snapshot(source_snapshot_id, source_region, description = nil)
+        def copy_snapshot(source_snapshot_id, source_region, description = nil, options = {})
           response = Excon::Response.new
           response.status = 200
           snapshot_id = Fog::AWS::Mock.snapshot_id


### PR DESCRIPTION
This PR will allow to use `Encrypted` and `KmsKeyId` parameters while copying snapshots.
In other words will allow to encrypt a copy of an unencrypted snapshot.

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopySnapshot.html