### PR TITLE
Issue #387 Fog::Compute::AWS::Vpcs returns VPCs with nil ids

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_vpcs.rb
+++ b/lib/fog/aws/parsers/compute/describe_vpcs.rb
@@ -47,8 +47,10 @@ module Fog
               when 'isDefault'
                 @vpc['isDefault'] = value == 'true'        
               when 'item'
-                @response['vpcSet'] << @vpc
-                @vpc = { 'tagSet' => {}, 'ipv6CidrBlockAssociationSet' => {} }
+                if value =~ /^(true|false)/
+                  @response['vpcSet'] << @vpc
+                  @vpc = { 'tagSet' => {}, 'ipv6CidrBlockAssociationSet' => {} }
+                end
               when 'requestId'
                 @response[name] = value
               end


### PR DESCRIPTION
handle the case where item ends up being "associated" instead of a staring beginning with true or false