### PR TITLE
allow Gemfile-edge travis builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
     gemfile: gemfiles/Gemfile-edge
   - rvm: 2.3.0
     gemfile: Gemfile
-  - rvm: jruby-18mode
-    gemfile: gemfiles/Gemfile-ruby-1.8.7
   - rvm: jruby-19mode
     gemfile: gemfiles/Gemfile-ruby-1.9
   - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ matrix:
     gemfile: Gemfile
   allow_failures:
   - rvm: jruby-head
+    gemfile: Gemfile
+  - rvm: 2.2.0
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.3.0
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.1.1
+    gemfile: gemfiles/Gemfile-edge
 notifications:
   email: false
   irc:


### PR DESCRIPTION
Since fog-core is pinned in the gemspec, this is only useful information for upcoming upgrades to fog-core.