### PR TITLE
Drop Ruby<2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ branches:
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    gemfile: gemfiles/Gemfile-ruby-1.8.7
-  - rvm: 1.9.3
-    gemfile: gemfiles/Gemfile-ruby-1.9
   - rvm: 2.0.0
     gemfile: gemfiles/Gemfile-ruby-2.0
   - rvm: 2.1.0
@@ -27,8 +23,6 @@ matrix:
     gemfile: gemfiles/Gemfile-edge
   - rvm: 2.3.0
     gemfile: Gemfile
-  - rvm: jruby-19mode
-    gemfile: gemfiles/Gemfile-ruby-1.9
   - rvm: jruby-head
     gemfile: Gemfile
   allow_failures:

--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'shindo',  '~> 0.3'

--- a/gemfiles/Gemfile-ruby-1.8.7
+++ b/gemfiles/Gemfile-ruby-1.8.7
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem 'mime-types', '~> 1.16'
-gem 'nokogiri', '~> 1.5.11'
-
-gemspec :path => "../"

--- a/gemfiles/Gemfile-ruby-1.9
+++ b/gemfiles/Gemfile-ruby-1.9
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem 'json', '~> 1.8'
-gem 'mime-types', '~> 2.6', '>= 2.6.2'
-gem 'nokogiri', '~> 1.6.8'
-
-gemspec :path => "../"

--- a/lib/fog/aws/requests/kinesis/put_record.rb
+++ b/lib/fog/aws/requests/kinesis/put_record.rb
@@ -46,8 +46,7 @@ module Fog
           data = options.delete("Data")
           partition_key = options.delete("PartitionKey")
 
-          sample_method = RUBY_VERSION == "1.8.7" ? :choice : :sample
-          shard_id = stream["Shards"].send(sample_method)["ShardId"]
+          shard_id = stream["Shards"].sample["ShardId"]
           shard = stream["Shards"].detect{ |shard| shard["ShardId"] == shard_id }
           # store the records on the shard(s)
           shard["Records"] << {

--- a/lib/fog/aws/requests/kinesis/put_records.rb
+++ b/lib/fog/aws/requests/kinesis/put_records.rb
@@ -43,8 +43,7 @@ module Fog
           record_results = records.map { |r|
             sequence_number = next_sequence_number
 
-            sample_method = RUBY_VERSION == "1.8.7" ? :choice : :sample
-            shard_id = stream["Shards"].send(sample_method)["ShardId"]
+            shard_id = stream["Shards"].sample["ShardId"]
             shard = stream["Shards"].detect{ |shard| shard["ShardId"] == shard_id }
             # store the records on the shard(s)
             shard["Records"] << r.merge("SequenceNumber" => sequence_number)

--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -30,7 +30,6 @@ module Fog
         # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPUT.html
 
         def self.conforming_to_us_ascii!(keys, hash)
-          return if RUBY_VERSION =~ /^1\.8\./
           keys.each do |k|
             v = hash[k]
             if !v.encode(::Encoding::US_ASCII, :undef => :replace).eql?(v)

--- a/tests/helpers/collection_helper.rb
+++ b/tests/helpers/collection_helper.rb
@@ -39,12 +39,6 @@ def collection_tests(collection, params = {}, mocks_implemented = true)
         'none?', 'one?'
       ]
 
-      # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
-      # https://github.com/jruby/jruby/issues/1265
-      if RUBY_PLATFORM == "java" and JRUBY_VERSION =~ /1\.7\.[5-8]/
-        methods.delete('all?')
-      end
-
       methods.each do |enum_method|
         if collection.respond_to?(enum_method)
           tests("##{enum_method}").succeeds do

--- a/tests/models/storage/file_tests.rb
+++ b/tests/models/storage/file_tests.rb
@@ -43,10 +43,6 @@ Shindo.tests("Storage[:aws] | file", ["aws"]) do
       end
 
       tests('#versions are all for the correct key').returns(true) do
-        # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
-        # https://github.com/jruby/jruby/issues/1265
-        pending if RUBY_PLATFORM == "java" and JRUBY_VERSION =~ /1\.7\.[5-8]/
-
         @instance.versions.all? { |v| v.key == @instance.key }
       end
     end

--- a/tests/models/storage/url_tests.rb
+++ b/tests/models/storage/url_tests.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 Shindo.tests('AWS | url', ["aws"]) do
 
-
   @storage = Fog::Storage.new(
     :provider => 'AWS',
     :aws_access_key_id => '123',
@@ -12,15 +11,7 @@ Shindo.tests('AWS | url', ["aws"]) do
   @file = @storage.directories.new(:key => 'fognonbucket').files.new(:key => 'test.txt')
 
   now = Fog::Time.now
-  if RUBY_VERSION > '1.8.7' # ruby 1.8.x doesn't provide hash ordering
-    tests('#v4 url w/ response-cache-control').returns(
-      "https://fognonbucket.s3.amazonaws.com/test.txt?response-cache-control=No-cache&X-Amz-Expires=500&X-Amz-Date=#{now.to_iso8601_basic}&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=123/#{now.utc.strftime('%Y%m%d')}/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature="
-    ) do
-
-      @file.url(now + 500, :query => { 'response-cache-control' => 'No-cache' }).gsub(/(X-Amz-Signature=)[0-9a-f]+\z/,'\\1')
-    end
-  end
-
+  
   @storage = Fog::Storage.new(
     :provider => 'AWS',
     :aws_access_key_id => '123',
@@ -30,15 +21,5 @@ Shindo.tests('AWS | url', ["aws"]) do
   )
 
   @file = @storage.directories.new(:key => 'fognonbucket').files.new(:key => 'test.txt')
-
-  if RUBY_VERSION > '1.8.7' # ruby 1.8.x doesn't provide hash ordering
-    tests('#v2 url w/ response-cache-control').returns(
-      "https://fognonbucket.s3.amazonaws.com/test.txt?response-cache-control=No-cache&AWSAccessKeyId=123&Signature=foo&Expires=#{now.to_i + 500}"
-    ) do
-
-      @file.url(now + 500, :query => { 'response-cache-control' => 'No-cache' })
-    end
-  end
-
 
 end

--- a/tests/requests/storage/object_tests.rb
+++ b/tests/requests/storage/object_tests.rb
@@ -18,12 +18,6 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file)
     end
 
-    if RUBY_VERSION =~ /^1\.8\./
-      tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").succeeds do
-        Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
-      end
-    end
-
     tests("#copy_object('#{@directory.identity}', 'fog_object', '#{@directory.identity}', 'fog_other_object')").succeeds do
       Fog::Storage[:aws].copy_object(@directory.identity, 'fog_object', @directory.identity, 'fog_other_object')
     end
@@ -177,10 +171,8 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].put_object(fognonbucket, 'fog_non_object', lorem_file)
     end
 
-    unless RUBY_VERSION =~ /^1\.8\./
-      tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").raises(Excon::Errors::BadRequest) do
-        Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
-      end
+    tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").raises(Excon::Errors::BadRequest) do
+      Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
     end
 
     tests("#copy_object('#{fognonbucket}', 'fog_object', '#{@directory.identity}', 'fog_other_object')").raises(Excon::Errors::NotFound) do


### PR DESCRIPTION
Users requiring ruby 1.9 or older should use the main fog gem.