### PR TITLE
Update rds instance options model

### DIFF
--- a/lib/fog/aws/models/rds/instance_option.rb
+++ b/lib/fog/aws/models/rds/instance_option.rb
@@ -10,6 +10,12 @@ module Fog
         attribute :availability_zones, :aliases => 'AvailabilityZones', :type => :array
         attribute :db_instance_class, :aliases => 'DBInstanceClass'
         attribute :vpc, :aliases => 'Vpc', :type => :boolean
+        attribute :supports_iops, :aliases => 'SupportsIops', :type => :boolean
+        attribute :supports_enhanced_monitoring, :aliases => 'SupportsEnhancedMonitoring', :type => :boolean
+        attribute :supports_iam_database_authentication, :aliases => 'SupportsIAMDatabaseAuthentication', :type => :boolean
+        attribute :supports_performance_insights, :aliases => 'SupportsPerformanceInsights', :type => :boolean
+        attribute :supports_storage_encryption, :aliases => 'SupportsStorageEncryption', :type => :boolean
+        attribute :storage_type, :aliases => 'StorageType'
       end
     end
   end

--- a/lib/fog/aws/parsers/rds/describe_orderable_db_instance_options.rb
+++ b/lib/fog/aws/parsers/rds/describe_orderable_db_instance_options.rb
@@ -19,12 +19,13 @@ module Fog
 
           def end_element(name)
             case name
-            when 'MultiAZCapable', 'ReadReplicaCapable', 'Vpc' then @db_instance_option[name] = to_boolean(value)
-            when 'Engine', 'LicenseModel', 'EngineVersion', 'DBInstanceClass' then @db_instance_option[name] = value
+            when 'MultiAZCapable', 'ReadReplicaCapable', 'Vpc', 'SupportsIops',
+                 'SupportsEnhancedMonitoring', 'SupportsIAMDatabaseAuthentication',
+                 'SupportsPerformanceInsights', 'SupportsStorageEncryption' then @db_instance_option[name] = to_boolean(value)
+            when 'Engine', 'LicenseModel', 'EngineVersion', 'DBInstanceClass', 'StorageType' then @db_instance_option[name] = value
             when 'AvailabilityZones' then @db_instance_option[name] = @availability_zones
             when 'AvailabilityZone' then @availability_zones << @availability_zone unless @availability_zone.empty?
             when 'Name' then @availability_zone[name] = value
-            when 'ProvisionedIopsCapable' then @availability_zone[name] = to_boolean(value)
             when 'OrderableDBInstanceOption'
               @db_instance_options << @db_instance_option
               @db_instance_option = {}

--- a/lib/fog/aws/requests/rds/describe_orderable_db_instance_options.rb
+++ b/lib/fog/aws/requests/rds/describe_orderable_db_instance_options.rb
@@ -4,8 +4,8 @@ module Fog
       class Real
         require 'fog/aws/parsers/rds/describe_orderable_db_instance_options'
 
-        # Describe all or specified load db instances
-        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
+        # Describe all or specified orderable db instances options
+        # https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeOrderableDBInstanceOptions.html
         # ==== Parameters
         # * Engine <~String> - The name of the engine to retrieve DB Instance options for. Required.
         # * Options <~Hash> - Hash of options. Optional. The following keys are used:

--- a/lib/fog/aws/requests/rds/describe_orderable_db_instance_options.rb
+++ b/lib/fog/aws/requests/rds/describe_orderable_db_instance_options.rb
@@ -47,11 +47,17 @@ module Fog
                                    'ReadReplicaCapable' => true,
                                    'EngineVersion' => opts[:engine_version] || '5.6.12',
                                    'AvailabilityZones' => [
-                                      {'Name' => 'us-east-1b', 'ProvisionedIopsCapable' => true},
-                                      {'Name' => 'us-east-1c', 'ProvisionedIopsCapable' => true},
-                                      {'Name' => 'us-east-1d', 'ProvisionedIopsCapable' => false},
-                                      {'Name' => 'us-east-1e', 'ProvisionedIopsCapable' => true}],
+                                      {'Name' => 'us-east-1b'},
+                                      {'Name' => 'us-east-1c'},
+                                      {'Name' => 'us-east-1d'},
+                                      {'Name' => 'us-east-1e'}],
                                    'DBInstanceClass' => size,
+                                   'SupportsStorageEncryption' => true,
+                                   'SupportsPerformanceInsights' => false,
+                                   'StorageType' => 'gp2',
+                                   'SupportsIops' => false,
+                                   'SupportsIAMDatabaseAuthentication' => false,
+                                   'SupportsEnhancedMonitoring' => true,
                                    'Vpc' => opts[:vpc].nil? ? true : opts[:vpc]}
 
             end

--- a/tests/requests/rds/helper.rb
+++ b/tests/requests/rds/helper.rb
@@ -6,8 +6,7 @@ class AWS
       }
 
       DB_AVAILABILITY_ZONE_OPTION = {
-        'Name' => String,
-        'ProvisionedIopsCapable' => Fog::Boolean
+        'Name' => String
       }
 
       DB_PARAMETER_GROUP = {
@@ -89,6 +88,12 @@ class AWS
         'EngineVersion' => String,
         'AvailabilityZones' => [DB_AVAILABILITY_ZONE_OPTION],
         'DBInstanceClass' => String,
+        'SupportsStorageEncryption' => Fog::Boolean,
+        'SupportsPerformanceInsights' => Fog::Boolean,
+        'StorageType' => String,
+        'SupportsIops' => Fog::Boolean,
+        'SupportsIAMDatabaseAuthentication' => Fog::Boolean,
+        'SupportsEnhancedMonitoring' => Fog::Boolean,
         'Vpc' => Fog::Boolean
       }
 

--- a/tests/requests/rds/instance_option_tests.rb
+++ b/tests/requests/rds/instance_option_tests.rb
@@ -12,7 +12,13 @@ Shindo.tests('AWS::RDS | db instance option requests', ['aws', 'rds']) do
       returns( 'mysql' ) { group['Engine'] }
       returns( true ) { group['ReadReplicaCapable'] }
       returns( true ) { group['AvailabilityZones'].length >= 1 }
-
+      returns( true ) { group['StorageType'].length > 2 }
+      returns( false ) { group['SupportsIops'] }
+      returns( true ) { group['SupportsStorageEncryption'] }
+      returns( false ) { group['SupportsPerformanceInsights'] }
+      returns( false ) { group['SupportsIops'] }
+      returns( false ) { group['SupportsIAMDatabaseAuthentication'] }
+      returns( true ) { group['SupportsEnhancedMonitoring'] }
       body
     end
 


### PR DESCRIPTION
While looking at issue #371 I noticed that the AWS API returns more data than was being exposed by fog, so I updated the model and parser to expose the remaining items and fixed a mismatch on checking for IOPS Support.