### PR TITLE
Add emulation of default VPC to mocked mode.

### DIFF
--- a/lib/fog/aws/mock.rb
+++ b/lib/fog/aws/mock.rb
@@ -145,6 +145,9 @@ module Fog
       def self.zone_id
         "zone-#{Fog::Mock.random_hex(8)}"
       end
+      def self.route_table_id
+        "rtb-#{Fog::Mock.random_hex(8)}"
+      end
       def self.change_id
         Fog::Mock.random_letters_and_numbers(14)
       end
@@ -180,6 +183,11 @@ module Fog
           'Windows',
           'SUSE Linux'
         ]
+      end
+
+      def self.default_vpc_for(region)
+        @default_vpcs ||= {}
+        @default_vpcs[region] ||= vpc_id
       end
     end
   end

--- a/lib/fog/aws/requests/compute/create_route_table.rb
+++ b/lib/fog/aws/requests/compute/create_route_table.rb
@@ -39,7 +39,7 @@ module Fog
           unless vpc.nil?
             response.status = 200
             route_table = {
-              'routeTableId' => "rtb-#{Fog::Mock.random_hex(8)}",
+              'routeTableId' => Fog::AWS::Mock.route_table_id,
               'vpcId' => vpc["vpcId"],
               'routeSet' => [{
                 "destinationCidrBlock" => vpc["cidrBlock"],

--- a/lib/fog/aws/requests/compute/create_security_group.rb
+++ b/lib/fog/aws/requests/compute/create_security_group.rb
@@ -33,6 +33,9 @@ module Fog
       class Mock
         def create_security_group(name, description, vpc_id=nil)
           response = Excon::Response.new
+
+          vpc_id ||= Fog::AWS::Mock.default_vpc_for(region)
+
           unless self.data[:security_groups][name]
             data = {
               'groupDescription'    => description,


### PR DESCRIPTION
When you create some resources in VPC-enabled environment (security groups, servers, load balaners etc.) AWS automatically attaches it to the default VPC. I am trying to emulate the same behavior in mocked mode. 

In order to to it I am going to create following resources:
- default vpc;
- internet gateway;
- routes table;
- subnets for each availability zone.

It's not possible to create such resources using requests cause:

1. It doesn't accept some attributes (e.g. `is_default` or `default_for_az`).
2. It creates resources in :pending state.

So I am going to push raw data to `data` collection.

Also I don't think it should be created by default because it may break some existing specs. So I propose to add a new method `Fog::Compute::AWS::Mock#setup_default_vpc!`. All data is stored in the class attribute so in order to use it you can create an instance of compute service and call this method, e.g.:

```ruby
compute = Fog::Compute.new(provider: 'aws', region: 'us-east-1')
compute.setup_default_vpc!
security_group = compute.create_security_group('test_group', 'New test group')
expect(security_group.vpc_id).to be_present
```

I am looking forward for your comments/suggestions.