### PR TITLE
Add jitter to exponential backoff

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -560,7 +560,16 @@ module Fog
                   Fog::Compute::AWS::NotFound.slurp(error, match[:message])
                 when 'RequestLimitExceeded'
                   if retries < max_retries
-                    sleep (2.0 ** (1.0 + retries) * 100) / 1000.0
+                    jitter = rand(100)
+                    waiting = true
+                    start_time = Time.now
+                    wait_time = ((2.0 ** (1.0 + retries) * 100) + jitter) / 1000.0
+                    puts "Waiting #{wait_time} seconds to retry."
+                    while waiting
+                      if Time.now - start_time >= wait_time
+                        waiting = false
+                      end
+                    end
                     retries += 1
                     retry
                   else

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -564,7 +564,7 @@ module Fog
                     waiting = true
                     start_time = Time.now
                     wait_time = ((2.0 ** (1.0 + retries) * 100) + jitter) / 1000.0
-                    puts "Waiting #{wait_time} seconds to retry."
+                    Fog::Logger.warning "Waiting #{wait_time} seconds to retry."
                     while waiting
                       if Time.now - start_time >= wait_time
                         waiting = false


### PR DESCRIPTION
Using exponential backoff alone is not adequate when launching multiple instances simultaneously. Jitter added to compensate for this.