### PR TITLE
Resolving issue where `Fog::Json` was called instead of `Fog::JSON`.

### DIFF
--- a/lib/fog/aws/requests/lambda/invoke.rb
+++ b/lib/fog/aws/requests/lambda/invoke.rb
@@ -18,7 +18,7 @@ module Fog
           headers = {}
           if client_context = params.delete('ClientContext')
             headers['X-Amz-Client-Context'] =
-              Base64::encode64(Fog::Json.encode(client_context))
+              Base64::encode64(Fog::JSON.encode(client_context))
           end
           if client_type = params.delete('InvocationType')
             headers['X-Amz-Client-Type'] = client_type


### PR DESCRIPTION
`Fog::Json` doesn't exist, so the call to `Fog::Json.encode` failed when providing a `ClientContext` as parameter to `Fog::Lambda#invoke`.

Changing to `Fog::JSON` (all-capitals) resolved this issue.