### PR TITLE
Expose elastic ip's private_ip_address

### DIFF
--- a/lib/fog/aws/models/compute/address.rb
+++ b/lib/fog/aws/models/compute/address.rb
@@ -4,6 +4,7 @@ module Fog
       class Address < Fog::Model
         identity  :public_ip,                  :aliases => 'publicIp'
 
+        attribute :private_ip_address,         :aliases => 'privateIpAddress'
         attribute :allocation_id,              :aliases => 'allocationId'
         attribute :association_id,             :aliases => 'associationId'
         attribute :server_id,                  :aliases => 'instanceId'

--- a/lib/fog/aws/parsers/compute/describe_addresses.rb
+++ b/lib/fog/aws/parsers/compute/describe_addresses.rb
@@ -10,7 +10,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'instanceId', 'publicIp', 'domain', 'allocationId', 'associationId', 'networkInterfaceId', 'networkInterfaceOwnerId'
+            when 'instanceId', 'publicIp', 'domain', 'allocationId', 'associationId', 'networkInterfaceId', 'networkInterfaceOwnerId', 'privateIpAddress'
               @address[name] = value
             when 'item'
               @response['addressesSet'] << @address


### PR DESCRIPTION
Hello guys, just a little PR for adding elastic ip's private_ip_address attributes (model address). (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAddresses.html)
Thanks.