### PR TITLE
Allow fog-core 2.0

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'shindo',  '~> 0.3'
   spec.add_development_dependency 'rubyzip', '~> 1.2.1'
 
-  spec.add_dependency 'fog-core',  '~> 1.38'
+  spec.add_dependency 'fog-core',  ['>= 1.38', '< 3']
   spec.add_dependency 'fog-json',  '~> 1.0'
   spec.add_dependency 'fog-xml',   '~> 0.1'
   spec.add_dependency 'ipaddress', '~> 0.8'


### PR DESCRIPTION
The [fog-core changelog](https://github.com/fog/fog-core/blob/master/changelog.md) entry for 2.0 says: 

> fix association reload drop ruby <2 support fix net-ssh usage add mime-type dependency