### PR TITLE
SetInstanceProtection endpoint for auto scaling groups support

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -48,6 +48,7 @@ module Fog
       request :resume_processes
       request :set_desired_capacity
       request :set_instance_health
+      request :set_instance_protection
       request :suspend_processes
       request :terminate_instance_in_auto_scaling_group
       request :update_auto_scaling_group

--- a/lib/fog/aws/models/auto_scaling/group.rb
+++ b/lib/fog/aws/models/auto_scaling/group.rb
@@ -99,6 +99,16 @@ module Fog
           reload
         end
 
+        def set_instance_protection(instance_ids, protected_from_scale_in)
+          requires :id
+          service.set_instance_protection(
+            id,
+            'InstanceIds' => instance_ids,
+            'ProtectedFromScaleIn' => protected_from_scale_in
+          )
+          reload
+        end
+
         def instances
           Fog::AWS::AutoScaling::Instances.new(:service => service).load(attributes[:instances])
         end

--- a/lib/fog/aws/requests/auto_scaling/set_instance_protection.rb
+++ b/lib/fog/aws/requests/auto_scaling/set_instance_protection.rb
@@ -1,0 +1,67 @@
+module Fog
+  module AWS
+    class AutoScaling
+      class Real
+        require 'fog/aws/parsers/auto_scaling/basic'
+
+        # Sets or removes scale in instance protection from one or more instances from the specified
+        # Auto Scaling group.
+        #
+        #  cli equiv:
+        # `aws autoscaling set-instance-protection --instance-ids i-5f2e8a0d --auto-scaling-group-name my-asg --protected-from-scale-in`
+        #
+        # ==== Parameters
+        #
+        #   * AutoScalingGroupName<~String> - The name of the Auto Scaling group``
+        #   * 'InstanceIds'<~Array> - The list of Auto Scaling instances to set or remove protection on.
+        #   * 'ProtectedFromScaleIn'<~Boolean> - Protection state
+        #
+        # ==== See Also
+        #
+        # https://docs.aws.amazon.com/autoscaling/latest/APIReference/API_SetInstanceProtection.html
+
+        ExpectedOptions[:asg_name] = %w[AutoScalingGroupName]
+        ExpectedOptions[:instance_ids] = %w[InstanceIds]
+        ExpectedOptions[:protected_from_scale_in] = %w[ProtectedFromScaleIn]
+
+        def set_instance_protection(auto_scaling_group_name, options = {})
+          if instance_ids = options.delete('InstanceIds')
+            options.merge!(AWS.indexed_param('InstanceIds.member.%d', [*instance_ids]))
+          end
+          protected_from_scale_in = options.delete('ProtectedFromScaleIn')
+
+          request({
+            'Action'               => 'SetInstanceProtection',
+            'AutoScalingGroupName' => auto_scaling_group_name,
+            'ProtectedFromScaleIn' => protected_from_scale_in,
+            :parser                => Fog::Parsers::AWS::AutoScaling::Basic.new
+          }.merge!(options))
+        end
+      end
+
+      class Mock
+        def set_instance_protection(auto_scaling_group_name, options = {})
+          unexpected_options = options.keys - \
+            ExpectedOptions[:asg_name] - \
+            ExpectedOptions[:instance_ids] - \
+            ExpectedOptions[:protected_from_scale_in]
+
+          unless unexpected_options.empty?
+            raise Fog::AWS::AutoScaling::ValidationError.new("Options #{unexpected_options.join(',')} should not be included in request")
+          end
+
+          unless self.data[:auto_scaling_groups].key?(auto_scaling_group_name)
+            raise Fog::AWS::AutoScaling::ValidationError.new('AutoScalingGroup name not found - null')
+          end
+
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'ResponseMetadata' => { 'RequestId' => Fog::AWS::Mock.request_id }
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/tests/requests/auto_scaling/auto_scaling_tests.rb
+++ b/tests/requests/auto_scaling/auto_scaling_tests.rb
@@ -51,6 +51,14 @@ Shindo.tests('AWS::AutoScaling | auto_scaling_tests', ['aws', 'auto_scaling']) d
       tests("#attach_instances").formats(AWS::AutoScaling::Formats::BASIC) do
         Fog::AWS[:auto_scaling].attach_instances(@asg_name, 'InstanceIds' => 'i-deadbeef').body
       end
+
+      tests("#set_instance_protection").formats(AWS::AutoScaling::Formats::BASIC) do
+        Fog::AWS[:auto_scaling].set_instance_protection(
+          @asg_name,
+          'InstanceIds' => 'i-deadbeef',
+          'ProtectedFromScaleIn' => true
+        ).body
+      end
     end
 
     tests("#describe_auto_scaling_groups").formats(AWS::AutoScaling::Formats::DESCRIBE_AUTO_SCALING_GROUPS) do


### PR DESCRIPTION
This PR adds support for SetInstanceProtection endpoint.

https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection
https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_SetInstanceProtection.html