### PR TITLE
Add encryption to EFS FileSystem creation

### DIFF
--- a/lib/fog/aws/models/efs/file_system.rb
+++ b/lib/fog/aws/models/efs/file_system.rb
@@ -7,6 +7,8 @@ module Fog
         attribute :owner_id,                :aliases => 'OwnerId'
         attribute :creation_token,          :aliases => 'CreationToken'
         attribute :performance_mode,        :aliases => 'PerformanceMode'
+        attribute :encrypted,               :aliases => 'Encrypted'
+        attribute :kms_key_id,              :aliases => 'KmsKeyId'
         attribute :creation_time,           :aliases => 'CreationTime'
         attribute :state,                   :aliases => 'LifeCycleState'
         attribute :name,                    :aliases => 'Name'
@@ -33,6 +35,8 @@ module Fog
         def save
           params = {}
           params.merge!(:performance_mode => self.performance_mode) if self.performance_mode
+          params.merge!(:encrypted        => self.encrypted)        if self.encrypted
+          params.merge!(:kms_key_id       => self.kms_key_id)       if self.kms_key_id
 
           merge_attributes(service.create_file_system(self.creation_token || Fog::Mock.random_hex(32), params).body)
         end

--- a/lib/fog/aws/requests/efs/create_file_system.rb
+++ b/lib/fog/aws/requests/efs/create_file_system.rb
@@ -7,17 +7,27 @@ module Fog
         # ==== Parameters
         # * CreationToken <~String> - String of up to 64 ASCII characters. Amazon EFS uses this to ensure idempotent creation.
         # * PerformanceMode <~String> - (Optional) The PerformanceMode of the file system. We recommend generalPurpose performance mode for most file systems. File systems using the maxIO performance mode can scale to higher levels of aggregate throughput and operations per second with a tradeoff of slightly higher latencies for most file operations. This can't be changed after the file system has been created.
+        # * Encrypted <~Boolean> - (Optional) A Boolean value that, if true, creates an encrypted file system. When creating an encrypted file system, you have the option of specifying a CreateFileSystem:KmsKeyId for an existing AWS Key Management Service (AWS KMS) customer master key (CMK). If you don't specify a CMK, then the default CMK for Amazon EFS, /aws/elasticfilesystem, is used to protect the encrypted file system. 
+        # * KmsKeyId <~String> - (Optional) The ID of the AWS KMS CMK to be used to protect the encrypted file system. This parameter is only required if you want to use a non-default CMK. If this parameter is not specified, the default CMK for Amazon EFS is used. This ID can be in one of the following formats:
+        #   - Key ID - A unique identifier of the key, for example, 1234abcd-12ab-34cd-56ef-1234567890ab.
+        #   - ARN - An Amazon Resource Name (ARN) for the key, for example, arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab.
+        #   - Key alias - A previously created display name for a key. For example, alias/projectKey1.
+        #   - Key alias ARN - An ARN for a key alias, for example, arn:aws:kms:us-west-2:444455556666:alias/projectKey1.
+        #   If KmsKeyId is specified, the CreateFileSystem:Encrypted parameter must be set to true.
         # ==== Returns
         # * response<~Excon::Response>
         #   * body<~Hash>
         def create_file_system(creation_token, options={})
-          request({
+          params = {
             :path             => "file-systems",
             :method           => 'POST',
             :expects          => 201,
             'CreationToken'   => creation_token,
-            'PerformanceMode' => options[:peformance_mode] || 'generalPurpose'
-          })
+            'PerformanceMode' => options[:peformance_mode] || 'generalPurpose',
+            'Encrypted'       => options[:encrypted] || false
+          }
+          params[:kms_key_id] = options[:kms_key_id] if options.key?(:kms_key_id)
+          request(params)
         end
       end
 
@@ -30,6 +40,7 @@ module Fog
             "OwnerId"              => Fog::AWS::Mock.owner_id,
             "CreationToken"        => creation_token,
             "PerformanceMode"      => options[:performance_mode] || "generalPurpose",
+            "Encrypted"            => options[:encrypted] || false,
             "FileSystemId"         => id,
             "CreationTime"         => Time.now.to_i.to_f,
             "LifeCycleState"       => "creating",
@@ -39,6 +50,7 @@ module Fog
               "Timestamp" => Time.now.to_i.to_f
             }
           }
+          file_system[:kms_key_id] = options[:kms_key_id] if options.key?(:kms_key_id)
 
           self.data[:file_systems][id] = file_system
           response.body = file_system

--- a/tests/requests/efs/helper.rb
+++ b/tests/requests/efs/helper.rb
@@ -10,6 +10,8 @@ class AWS
         "NumberOfMountTargets" => Integer,
         "OwnerId"              => String,
         "PerformanceMode"      => String,
+        "Encrypted"            => Fog::Nullable::Boolean,
+        "KmsKeyId"             => Fog::Nullable::String,
         "SizeInBytes"          => {
           "Timestamp" => Fog::Nullable::Float,
           "Value"     => Integer


### PR DESCRIPTION
These parameters are:
* encrypted
* kms_key_id

Both are optional, but encrypted MUST be true if kms_key_id is specified.

I did not add the additional fields to the tests because the PerformanceMode was not included in the tests, and I  was trying to keep things consistent. But I am happy to update the tests, and I can try to add overriding the PreformanceMode field as well.