### PR TITLE
fix: attach volume on #save, remove #server=

### DIFF
--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -117,6 +117,10 @@ module Fog
           end
         end
 
+        def server=(_)
+          raise NoMethodError, 'use Fog::Compute::AWS::Volume#attach(server, device)'
+        end
+
         private
 
         def attachmentSet=(new_attachment_set)

--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -21,7 +21,7 @@ module Fog
 
         def initialize(attributes = {})
           # assign server first to prevent race condition with persisted?
-          self.server = attributes.delete(:server)
+          @server = attributes.delete(:server)
           super
         end
 
@@ -70,18 +70,16 @@ module Fog
               service.create_tags(identity, tags)
             end
 
-            attach(@service, device) if @server
-
-            true
+            attach(@server, device) if @server && device
           end
+
+          true
         end
 
         def server
           requires :server_id
           service.servers.get(server_id)
         end
-
-        attr_writer :server
 
         def snapshots
           requires :id

--- a/tests/models/compute/volume_tests.rb
+++ b/tests/models/compute/volume_tests.rb
@@ -25,6 +25,10 @@ Shindo.tests('Fog::Compute[:aws] | volume', ['aws']) do
       @instance.server.nil?
     end
 
+    tests('#server=').raises(NoMethodError, 'use Fog::Compute::AWS::Volume#attach(server, device)') do
+      @instance.server = @server
+    end
+
     tests('#attach(server, device)').succeeds do
       @instance.attach(@server, '/dev/sdz1')
       @instance.server == @server


### PR DESCRIPTION
`s/service/server/` in `Volume#save`.  Fixes attaching after initialization.

Require users to call `Volume#attach(server, device)` to attach a volume after it's created.  `Volume#server=(new_server)` having a side-effect of attaching a volume is confusing.

`Volume#device` set on `Volume#initialize` will be lost when calling `Volume#wait_for` in fog-core ~> 2.0.

BREAKING CHANGE

`Volume#server=` is removed.