### PR TITLE
Retry if  instance not found when adding EC2 tags

### DIFF
--- a/lib/fog/aws/models/compute/servers.rb
+++ b/lib/fog/aws/models/compute/servers.rb
@@ -162,6 +162,7 @@ module Fog
             server.merge_attributes(instance_set)
             # expect eventual consistency
             if (tags = server.tags) && tags.size > 0
+              Fog.wait_for { server.reload rescue nil }
               Fog.wait_for {
                 begin
                   service.create_tags(server.identity, tags)

--- a/lib/fog/aws/models/compute/servers.rb
+++ b/lib/fog/aws/models/compute/servers.rb
@@ -162,7 +162,6 @@ module Fog
             server.merge_attributes(instance_set)
             # expect eventual consistency
             if (tags = server.tags) && tags.size > 0
-              Fog.wait_for { server.reload rescue nil }
               Fog.wait_for {
                 begin
                   service.create_tags(server.identity, tags)

--- a/lib/fog/aws/models/compute/servers.rb
+++ b/lib/fog/aws/models/compute/servers.rb
@@ -163,10 +163,13 @@ module Fog
             # expect eventual consistency
             if (tags = server.tags) && tags.size > 0
               Fog.wait_for { server.reload rescue nil }
-              service.create_tags(
-                server.identity,
-                tags
-              )
+              Fog.wait_for {
+                begin
+                  service.create_tags(server.identity, tags)
+                rescue Fog::Compute::AWS::NotFound
+                  false
+                end
+              }
             end
             server
           end


### PR DESCRIPTION
Retry is necessary because AWS is eventually consistent. Not doing so
occassionally results in instance tags not being applied.  The specific
error is:
  The instance ID 'i-0e800893aa8d116a1' does not exist (Fog::Compute::AWS::NotFound)

Refer to AWS docs regarding eventual consistency's
InvalidInstanceID.NotFound error