### PR TITLE
Fix c1.xlarge cpu count

### DIFF
--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -138,7 +138,7 @@ module Fog
           :id                      => 'c1.xlarge',
           :name                    => 'High-CPU Extra Large',
           :bits                    => 64,
-          :cores                   => 20,
+          :cores                   => 8,
           :disk                    => 1690,
           :ram                     => 7168,
           :ebs_optimized_available => true,


### PR DESCRIPTION
Hey, just found a little error, c1.xlarge flavors actually have 8 cpus, not 20.

See : https://aws.amazon.com/ec2/previous-generation/
<img width="865" alt="screen shot 2018-06-20 at 15 30 17" src="https://user-images.githubusercontent.com/102168/41661368-e16b9e94-749e-11e8-9840-b614bd90943e.png">
