### PR TITLE
Fix & update aws flavor (provided in GiB) to Megabytes (floor rounded).

### DIFF
--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -10,7 +10,7 @@ module Fog
           :bits                    => 0,
           :cores                   => 1,
           :disk                    => 0,
-          :ram                     => 613,
+          :ram                     => 658,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -20,7 +20,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 1,
           :disk                    => 0,
-          :ram                     => 512,
+          :ram                     => 536,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -30,7 +30,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 1,
           :disk                    => 0,
-          :ram                     => 1024,
+          :ram                     => 1073,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -40,7 +40,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 1,
           :disk                    => 0,
-          :ram                     => 2048,
+          :ram                     => 2147,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -50,7 +50,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 0,
-          :ram                     => 4096,
+          :ram                     => 4294,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -60,7 +60,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 0,
-          :ram                     => 8192,
+          :ram                     => 8589,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -70,7 +70,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 0,
-          :ram                     => 16384,
+          :ram                     => 17179,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -80,7 +80,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 0,
-          :ram                     => 32768,
+          :ram                     => 34359,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 0
         },
@@ -90,7 +90,7 @@ module Fog
           :bits                    => 32,
           :cores                   => 1,
           :disk                    => 160,
-          :ram                     => 1740.8,
+          :ram                     => 1825,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -100,7 +100,7 @@ module Fog
           :bits                    => 32,
           :cores                   => 1,
           :disk                    => 400,
-          :ram                     => 3750,
+          :ram                     => 4026,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -110,7 +110,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 850,
-          :ram                     => 7680,
+          :ram                     => 8053,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -120,7 +120,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 1690,
-          :ram                     => 15360,
+          :ram                     => 16106,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 4
         },
@@ -130,7 +130,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 350,
           :name                    => 'High-CPU Medium',
-          :ram                     => 1740.8,
+          :ram                     => 1825,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -140,7 +140,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 1690,
-          :ram                     => 7168,
+          :ram                     => 7516,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 4
         },
@@ -150,7 +150,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 32,
-          :ram                     => 3750,
+          :ram                     => 4026,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 2
         },
@@ -160,7 +160,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 80,
-          :ram                     => 7168,
+          :ram                     => 8053,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -170,7 +170,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 160,
-          :ram                     => 15360,
+          :ram                     => 16106,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -180,7 +180,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 320,
-          :ram                     => 30720,
+          :ram                     => 32212,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -190,7 +190,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 640,
-          :ram                     => 61440,
+          :ram                     => 64424,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 2
         },
@@ -200,7 +200,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 0,
-          :ram                     => 3750,
+          :ram                     => 4026,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -210,7 +210,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 0,
-          :ram                     => 7168,
+          :ram                     => 8053,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -220,7 +220,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 0,
-          :ram                     => 15360,
+          :ram                     => 16106,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -230,7 +230,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 0,
-          :ram                     => 30720,
+          :ram                     => 32212,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -240,7 +240,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 36,
           :disk                    => 0,
-          :ram                     => 61440,
+          :ram                     => 64424,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -250,7 +250,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 0,
-          :ram                     => 4096,
+          :ram                     => 4294,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -260,7 +260,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 0,
-          :ram                     => 8192,
+          :ram                     => 8589,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -270,7 +270,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 0,
-          :ram                     => 16384,
+          :ram                     => 17179,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -280,7 +280,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 0,
-          :ram                     => 32768,
+          :ram                     => 34359,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -290,7 +290,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 36,
           :disk                    => 0,
-          :ram                     => 73728,
+          :ram                     => 77309,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -300,7 +300,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 72,
           :disk                    => 0,
-          :ram                     => 147456,
+          :ram                     => 154618,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -310,7 +310,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 60,
-          :ram                     => 15360,
+          :ram                     => 16106,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -320,7 +320,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 240,
-          :ram                     => 61440,
+          :ram                     => 64424,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -330,7 +330,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 50331648,
-          :ram                     => 119808,
+          :ram                     => 125627,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 24
         },
@@ -340,7 +340,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 420,
-          :ram                     => 17510.4,
+          :ram                     => 18360,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -350,7 +350,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 850,
-          :ram                     => 35020.8,
+          :ram                     => 36721,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -360,7 +360,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 1690,
-          :ram                     => 70041.6,
+          :ram                     => 73443,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -370,7 +370,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 240,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 2
         },
@@ -380,7 +380,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 1,
           :disk                    => 4,
-          :ram                     => 3840,
+          :ram                     => 4026,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -390,7 +390,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 32,
-          :ram                     => 7680,
+          :ram                     => 8053,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
         },
@@ -400,7 +400,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 80,
-          :ram                     => 15360,
+          :ram                     => 16106,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -410,7 +410,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 160,
-          :ram                     => 30720,
+          :ram                     => 32212,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -440,7 +440,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 3370,
-          :ram                     => 61952,
+          :ram                     => 64961,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 4
         },
@@ -460,7 +460,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 800,
-          :ram                     => 31232,
+          :ram                     => 32749,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -470,7 +470,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 1600,
-          :ram                     => 62464,
+          :ram                     => 65498,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -480,7 +480,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 3200,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 4
         },
@@ -490,7 +490,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 6400,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 8
         },
@@ -500,7 +500,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 2,
           :disk                    => 475,
-          :ram                     => 15616,
+          :ram                     => 16374,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -510,7 +510,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 4,
           :disk                    => 950,
-          :ram                     => 31232,
+          :ram                     => 32749,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -520,7 +520,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 8,
           :disk                    => 1900,
-          :ram                     => 62464,
+          :ram                     => 65498,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
         },
@@ -530,7 +530,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 3800,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 2
         },
@@ -540,7 +540,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 7600,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 4
         },
@@ -550,7 +550,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 64,
           :disk                    => 15200,
-          :ram                     => 499712,
+          :ram                     => 523986,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 8
         },
@@ -559,7 +559,7 @@ module Fog
           :name                    => "R3 Large",
           :bits                    => 64,
           :cores                   => 2,
-          :ram                     => 15616,
+          :ram                     => 16374,
           :disk                    => 32,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 1
@@ -569,7 +569,7 @@ module Fog
           :name                    => "R3 Extra Large",
           :bits                    => 64,
           :cores                   => 4,
-          :ram                     => 31232,
+          :ram                     => 32749,
           :disk                    => 80,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
@@ -579,7 +579,7 @@ module Fog
           :name                    => "R3 Double Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 62464,
+          :ram                     => 65498,
           :disk                    => 160,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
@@ -589,7 +589,7 @@ module Fog
           :name                    => "R3 Quadruple Extra Large",
           :bits                    => 64,
           :cores                   => 16,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :disk                    => 320,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 1
@@ -599,7 +599,7 @@ module Fog
           :name                    => "R3 Eight Extra Large",
           :bits                    => 64,
           :cores                   => 32,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :disk                    => 640,
           :ebs_optimized_available => false,
           :instance_store_volumes  => 2
@@ -609,7 +609,7 @@ module Fog
           :name                    => "R4 Large",
           :bits                    => 64,
           :cores                   => 2,
-          :ram                     => 15616,
+          :ram                     => 16374,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -619,7 +619,7 @@ module Fog
           :name                    => "R4 Extra Large",
           :bits                    => 64,
           :cores                   => 4,
-          :ram                     => 31232,
+          :ram                     => 32749,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -629,7 +629,7 @@ module Fog
           :name                    => "R4 Double Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 62464,
+          :ram                     => 65498,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -639,7 +639,7 @@ module Fog
           :name                    => "R4 Quadruple Extra Large",
           :bits                    => 64,
           :cores                   => 16,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -649,7 +649,7 @@ module Fog
           :name                    => "R4 Eight Extra Large",
           :bits                    => 64,
           :cores                   => 32,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -659,7 +659,7 @@ module Fog
           :name                    => "R4 Sixteen Extra Large",
           :bits                    => 64,
           :cores                   => 64,
-          :ram                     => 499712,
+          :ram                     => 523986,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -669,7 +669,7 @@ module Fog
           :name                    => "D2 Extra Large",
           :bits                    => 64,
           :cores                   => 4,
-          :ram                     => 31232,
+          :ram                     => 32749,
           :disk                    => 6000,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 3
@@ -679,7 +679,7 @@ module Fog
           :name                    => "D2 Double Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 62464,
+          :ram                     => 65498,
           :disk                    => 12000,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 6
@@ -689,7 +689,7 @@ module Fog
           :name                    => "D2 Quadruple Extra Large",
           :bits                    => 64,
           :cores                   => 16,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :disk                    => 24000,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 12
@@ -699,7 +699,7 @@ module Fog
           :name                    => "D2 Eight Extra Large",
           :bits                    => 64,
           :cores                   => 36,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :disk                    => 48000,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 24
@@ -709,7 +709,7 @@ module Fog
           :name                    => "M4 Large",
           :bits                    => 64,
           :cores                   => 2,
-          :ram                     => 8192,
+          :ram                     => 8589,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -719,7 +719,7 @@ module Fog
           :name                    => "M4 Extra Large",
           :bits                    => 64,
           :cores                   => 4,
-          :ram                     => 16384,
+          :ram                     => 17179,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -729,7 +729,7 @@ module Fog
           :name                    => "M4 Double Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 31232,
+          :ram                     => 34359,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -739,7 +739,7 @@ module Fog
           :name                    => "M4 Quadruple Extra Large",
           :bits                    => 64,
           :cores                   => 16,
-          :ram                     => 62464,
+          :ram                     => 68719,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -749,7 +749,7 @@ module Fog
           :name                    => "M4 Ten Extra Large",
           :bits                    => 64,
           :cores                   => 40,
-          :ram                     => 163840,
+          :ram                     => 171798,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -759,7 +759,7 @@ module Fog
           :name                    => "M5 Large",
           :bits                    => 64,
           :cores                   => 2,
-          :ram                     => 8192,
+          :ram                     => 8589,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -769,7 +769,7 @@ module Fog
           :name                    => "M5 Extra Large",
           :bits                    => 64,
           :cores                   => 4,
-          :ram                     => 16384,
+          :ram                     => 17179,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -779,7 +779,7 @@ module Fog
           :name                    => "M5 Double Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 32768,
+          :ram                     => 34359,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -789,7 +789,7 @@ module Fog
           :name                    => "M5 Quadruple Extra Large",
           :bits                    => 64,
           :cores                   => 16,
-          :ram                     => 65536,
+          :ram                     => 68719,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -799,7 +799,7 @@ module Fog
           :name                    => "M5 Twelve Extra Large",
           :bits                    => 64,
           :cores                   => 48,
-          :ram                     => 196608,
+          :ram                     => 206158,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -809,7 +809,7 @@ module Fog
           :name                    => "M5 Twenty Four Extra Large",
           :bits                    => 64,
           :cores                   => 96,
-          :ram                     => 393216,
+          :ram                     => 412316,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -849,7 +849,7 @@ module Fog
           :name                    => "Tesla GPU Two Extra Large",
           :bits                    => 64,
           :cores                   => 8,
-          :ram                     => 6100,
+          :ram                     => 65498,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -859,7 +859,7 @@ module Fog
           :name                    => "Tesla GPU Eight Extra Large",
           :bits                    => 64,
           :cores                   => 32,
-          :ram                     => 244000,
+          :ram                     => 261993,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -869,7 +869,7 @@ module Fog
           :name                    => "Tesla GPU Sixteen Extra Large",
           :bits                    => 64,
           :cores                   => 64,
-          :ram                     => 488000,
+          :ram                     => 523986,
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
@@ -880,7 +880,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 16,
           :disk                    => 0,
-          :ram                     => 124928,
+          :ram                     => 130996,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -890,7 +890,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 32,
           :disk                    => 0,
-          :ram                     => 249856,
+          :ram                     => 261993,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
@@ -900,7 +900,7 @@ module Fog
           :bits                    => 64,
           :cores                   => 64,
           :disk                    => 0,
-          :ram                     => 499712,
+          :ram                     => 523986,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         }


### PR DESCRIPTION
Updated from data available here:
- https://aws.amazon.com/ec2/pricing/on-demand/
- https://aws.amazon.com/ec2/previous-generation/
