### PR TITLE
Storage region support for cn-northwest-1

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -221,8 +221,8 @@ module Fog
           case region.to_s
           when DEFAULT_REGION, ''
             's3.amazonaws.com'
-          when 'cn-north-1'
-            's3.cn-north-1.amazonaws.com.cn'
+          when %r{\Acn-.*}
+            "s3.#{region}.amazonaws.com.cn"
           else
             "s3-#{region}.amazonaws.com"
           end


### PR DESCRIPTION
Adds generic support for CN regions in storage provider since AWS seem to be spinning up new ones.