### PR TITLE
Fix t1.micro bits

### DIFF
--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -7,7 +7,7 @@ module Fog
         {
           :id                      => 't1.micro',
           :name                    => 'Micro Instance',
-          :bits                    => 0,
+          :bits                    => 32,
           :cores                   => 1,
           :disk                    => 0,
           :ram                     => 658,


### PR DESCRIPTION
It's not a 0 bit instance. It's a 32bit instance.

Signed-off-by: Tim Smith <tsmith@chef.io>