### PR TITLE
Rename CDN::AWS to AWS::CDN

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -5,10 +5,6 @@ require 'fog/json'
 require File.expand_path('../aws/version', __FILE__)
 
 module Fog
-  module CDN
-    autoload :AWS,  File.expand_path('../aws/cdn', __FILE__)
-  end
-
   module Compute
     autoload :AWS, File.expand_path('../aws/compute', __FILE__)
   end
@@ -32,6 +28,7 @@ module Fog
 
     # Services
     autoload :AutoScaling,      File.expand_path('../aws/auto_scaling', __FILE__)
+    autoload :CDN,              File.expand_path('../aws/cdn', __FILE__)
     autoload :CloudFormation,   File.expand_path('../aws/cloud_formation', __FILE__)
     autoload :CloudWatch,       File.expand_path('../aws/cloud_watch', __FILE__)
     autoload :DataPipeline,     File.expand_path('../aws/data_pipeline', __FILE__)

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS < Fog::Service
+  module AWS
+    class CDN < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
@@ -201,3 +201,6 @@ EOF
     end
   end
 end
+
+# @deprecated
+Fog::CDN::AWS = Fog::AWS::CDN

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -200,7 +200,17 @@ EOF
       end
     end
   end
-end
 
-# @deprecated
-Fog::CDN::AWS = Fog::AWS::CDN
+  # @deprecated
+  module CDN
+    # @deprecated
+    class AWS < Fog::AWS::CDN
+      # @deprecated
+      # @overrides Fog::Service.new (from the fog-core gem)
+      def self.new(*)
+        Fog::Logger.deprecation 'Fog::CDN::AWS is deprecated, please use Fog::AWS::CDN.'
+        super
+      end
+    end
+  end
+end

--- a/lib/fog/aws/models/cdn/distribution.rb
+++ b/lib/fog/aws/models/cdn/distribution.rb
@@ -2,10 +2,10 @@ require 'fog/aws/models/cdn/invalidations'
 require 'fog/aws/models/cdn/distribution_helper'
 
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Distribution < Fog::Model
-        include Fog::CDN::AWS::DistributionHelper
+        include Fog::AWS::CDN::DistributionHelper
 
         identity :id,                 :aliases => 'Id'
 
@@ -33,7 +33,7 @@ module Fog
 
         def invalidations
           @invalidations ||= begin
-            Fog::CDN::AWS::Invalidations.new(
+            Fog::AWS::CDN::Invalidations.new(
               :distribution => self,
               :service => service
             )

--- a/lib/fog/aws/models/cdn/distribution_helper.rb
+++ b/lib/fog/aws/models/cdn/distribution_helper.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       module DistributionHelper
         def destroy
           requires :identity, :etag, :caller_reference

--- a/lib/fog/aws/models/cdn/distributions.rb
+++ b/lib/fog/aws/models/cdn/distributions.rb
@@ -2,12 +2,12 @@ require 'fog/aws/models/cdn/distribution'
 require 'fog/aws/models/cdn/distributions_helper'
 
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Distributions < Fog::Collection
-        include Fog::CDN::AWS::DistributionsHelper
+        include Fog::AWS::CDN::DistributionsHelper
 
-        model Fog::CDN::AWS::Distribution
+        model Fog::AWS::CDN::Distribution
 
         attribute :marker,    :aliases => 'Marker'
         attribute :max_items, :aliases => 'MaxItems'

--- a/lib/fog/aws/models/cdn/distributions_helper.rb
+++ b/lib/fog/aws/models/cdn/distributions_helper.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       module DistributionsHelper
 
         def all(options = {})

--- a/lib/fog/aws/models/cdn/invalidation.rb
+++ b/lib/fog/aws/models/cdn/invalidation.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Invalidation < Fog::Model
         identity :id,                :aliases => 'Id'
 

--- a/lib/fog/aws/models/cdn/invalidations.rb
+++ b/lib/fog/aws/models/cdn/invalidations.rb
@@ -1,8 +1,8 @@
 require 'fog/aws/models/cdn/invalidation'
 
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Invalidations < Fog::Collection
         attribute :is_truncated,            :aliases => ['IsTruncated']
         attribute :max_items,               :aliases => ['MaxItems']
@@ -11,7 +11,7 @@ module Fog
 
         attribute :distribution
 
-        model Fog::CDN::AWS::Invalidation
+        model Fog::AWS::CDN::Invalidation
 
         def all(options = {})
           requires :distribution

--- a/lib/fog/aws/models/cdn/streaming_distribution.rb
+++ b/lib/fog/aws/models/cdn/streaming_distribution.rb
@@ -2,10 +2,10 @@ require 'fog/aws/models/cdn/invalidations'
 require 'fog/aws/models/cdn/distribution_helper'
 
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class StreamingDistribution < Fog::Model
-        include Fog::CDN::AWS::DistributionHelper
+        include Fog::AWS::CDN::DistributionHelper
 
         identity :id,                 :aliases => 'Id'
 

--- a/lib/fog/aws/models/cdn/streaming_distributions.rb
+++ b/lib/fog/aws/models/cdn/streaming_distributions.rb
@@ -2,12 +2,12 @@ require 'fog/aws/models/cdn/streaming_distribution'
 require 'fog/aws/models/cdn/distributions_helper'
 
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class StreamingDistributions < Fog::Collection
-        include Fog::CDN::AWS::DistributionsHelper
+        include Fog::AWS::CDN::DistributionsHelper
 
-        model Fog::CDN::AWS::StreamingDistribution
+        model Fog::AWS::CDN::StreamingDistribution
 
         attribute :marker,    :aliases => 'Marker'
         attribute :max_items, :aliases => 'MaxItems'

--- a/lib/fog/aws/parsers/cdn/distribution.rb
+++ b/lib/fog/aws/parsers/cdn/distribution.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class Distribution < Fog::Parsers::Base
           def reset
             @response = { 'DistributionConfig' => { 'CNAME' => [], 'Logging' => {}, 'TrustedSigners' => [] } }

--- a/lib/fog/aws/parsers/cdn/get_distribution_list.rb
+++ b/lib/fog/aws/parsers/cdn/get_distribution_list.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class GetDistributionList < Fog::Parsers::Base
           def reset
             @distribution_summary = { 'CNAME' => [], 'TrustedSigners' => [] }

--- a/lib/fog/aws/parsers/cdn/get_invalidation.rb
+++ b/lib/fog/aws/parsers/cdn/get_invalidation.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class GetInvalidation < Fog::Parsers::Base
           def reset
             @response = { 'InvalidationBatch' => { 'Path' => [] } }

--- a/lib/fog/aws/parsers/cdn/get_invalidation_list.rb
+++ b/lib/fog/aws/parsers/cdn/get_invalidation_list.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class GetInvalidationList < Fog::Parsers::Base
           def reset
             @invalidation_summary = { }

--- a/lib/fog/aws/parsers/cdn/get_streaming_distribution_list.rb
+++ b/lib/fog/aws/parsers/cdn/get_streaming_distribution_list.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class GetStreamingDistributionList < Fog::Parsers::Base
           def reset
             @distribution_summary = { 'CNAME' => [], 'TrustedSigners' => [] }

--- a/lib/fog/aws/parsers/cdn/post_invalidation.rb
+++ b/lib/fog/aws/parsers/cdn/post_invalidation.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
-    module CDN
-      module AWS
+    module AWS
+      module CDN
         class PostInvalidation < Fog::Parsers::Base
           def reset
             @response = { 'InvalidationBatch' => { 'Path' => [] } }

--- a/lib/fog/aws/parsers/cdn/streaming_distribution.rb
+++ b/lib/fog/aws/parsers/cdn/streaming_distribution.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
+    module AWS
       module CDN
-        module AWS
 
         class StreamingDistribution < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/requests/cdn/delete_distribution.rb
+++ b/lib/fog/aws/requests/cdn/delete_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         # Delete a distribution from CloudFront.
         #
@@ -26,13 +26,13 @@ module Fog
 
           if distribution
             if distribution['ETag'] != etag
-              Fog::CDN::AWS::Mock.error(:invalid_if_match_version)
+              Fog::AWS::CDN::Mock.error(:invalid_if_match_version)
             end
             unless distribution['DistributionConfig']['CallerReference']
-              Fog::CDN::AWS::Mock.error(:illegal_update)
+              Fog::AWS::CDN::Mock.error(:illegal_update)
             end
             if distribution['DistributionConfig']['Enabled']
-              Fog::CDN::AWS::Mock.error(:distribution_not_disabled)
+              Fog::AWS::CDN::Mock.error(:distribution_not_disabled)
             end
 
             self.data[:distributions].delete(distribution_id)
@@ -43,7 +43,7 @@ module Fog
             response.body = "x-amz-request-id: #{Fog::AWS::Mock.request_id}"
             response
           else
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
         end
       end

--- a/lib/fog/aws/requests/cdn/delete_streaming_distribution.rb
+++ b/lib/fog/aws/requests/cdn/delete_streaming_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         # Delete a streaming distribution from CloudFront.
         #
@@ -26,13 +26,13 @@ module Fog
 
           if distribution
             if distribution['ETag'] != etag
-              Fog::CDN::AWS::Mock.error(:invalid_if_match_version)
+              Fog::AWS::CDN::Mock.error(:invalid_if_match_version)
             end
             unless distribution['StreamingDistributionConfig']['CallerReference']
-              Fog::CDN::AWS::Mock.error(:illegal_update)
+              Fog::AWS::CDN::Mock.error(:illegal_update)
             end
             if distribution['StreamingDistributionConfig']['Enabled']
-              Fog::CDN::AWS::Mock.error(:distribution_not_disabled)
+              Fog::AWS::CDN::Mock.error(:distribution_not_disabled)
             end
 
             self.data[:streaming_distributions].delete(distribution_id)
@@ -42,7 +42,7 @@ module Fog
             response.body = "x-amz-request-id: #{Fog::AWS::Mock.request_id}"
             response
           else
-            Fog::CDN::AWS::Mock.error(:no_such_streaming_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_streaming_distribution)
           end
         end
       end

--- a/lib/fog/aws/requests/cdn/get_distribution.rb
+++ b/lib/fog/aws/requests/cdn/get_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/distribution'
 
@@ -42,7 +42,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::CDN::AWS::Distribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::Distribution.new,
             :path       => "/distribution/#{distribution_id}"
           })
         end
@@ -54,14 +54,14 @@ module Fog
 
           distribution = self.data[:distributions][distribution_id]
           unless distribution
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
 
           if distribution['Status'] == 'InProgress' && (Time.now - Time.parse(distribution['LastModifiedTime']) >= Fog::Mock.delay * 2)
             distribution['Status'] = 'Deployed'
           end
 
-          etag = Fog::CDN::AWS::Mock.generic_id
+          etag = Fog::AWS::CDN::Mock.generic_id
           response.status = 200
           response.body = {
             'InProgressInvalidationBatches' => 0,

--- a/lib/fog/aws/requests/cdn/get_distribution_list.rb
+++ b/lib/fog/aws/requests/cdn/get_distribution_list.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/get_distribution_list'
 
@@ -42,7 +42,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::CDN::AWS::GetDistributionList.new,
+            :parser   => Fog::Parsers::AWS::CDN::GetDistributionList.new,
             :path       => "/distribution",
             :query      => options
           })

--- a/lib/fog/aws/requests/cdn/get_invalidation.rb
+++ b/lib/fog/aws/requests/cdn/get_invalidation.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/get_invalidation'
 
@@ -24,7 +24,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::CDN::AWS::GetInvalidation.new,
+            :parser   => Fog::Parsers::AWS::CDN::GetInvalidation.new,
             :path       => "/distribution/#{distribution_id}/invalidation/#{invalidation_id}"
           })
         end
@@ -34,12 +34,12 @@ module Fog
         def get_invalidation(distribution_id, invalidation_id)
           distribution = self.data[:distributions][distribution_id]
           unless distribution
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
 
           invalidation = self.data[:invalidations][distribution_id][invalidation_id]
           unless invalidation
-            Fog::CDN::AWS::Mock.error(:no_such_invalidation)
+            Fog::AWS::CDN::Mock.error(:no_such_invalidation)
           end
 
           if invalidation['Status'] == 'InProgress' && (Time.now - Time.parse(invalidation['CreateTime']) >= Fog::Mock.delay * 2)

--- a/lib/fog/aws/requests/cdn/get_invalidation_list.rb
+++ b/lib/fog/aws/requests/cdn/get_invalidation_list.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/get_invalidation_list'
 
@@ -27,7 +27,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::CDN::AWS::GetInvalidationList.new,
+            :parser   => Fog::Parsers::AWS::CDN::GetInvalidationList.new,
             :path       => "/distribution/#{distribution_id}/invalidation",
             :query      => options
           })
@@ -38,7 +38,7 @@ module Fog
         def get_invalidation_list(distribution_id, options = {})
           distribution = self.data[:distributions][distribution_id]
           unless distribution
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
 
           invalidations = (self.data[:invalidations][distribution_id] || {}).values

--- a/lib/fog/aws/requests/cdn/get_streaming_distribution.rb
+++ b/lib/fog/aws/requests/cdn/get_streaming_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/streaming_distribution'
 
@@ -35,7 +35,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::CDN::AWS::StreamingDistribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::StreamingDistribution.new,
             :path       => "/streaming-distribution/#{distribution_id}"
           })
         end
@@ -47,14 +47,14 @@ module Fog
 
           distribution = self.data[:streaming_distributions][distribution_id]
           unless distribution
-            Fog::CDN::AWS::Mock.error(:no_such_streaming_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_streaming_distribution)
           end
 
           if distribution['Status'] == 'InProgress' && (Time.now - Time.parse(distribution['LastModifiedTime']) >= Fog::Mock.delay * 2)
             distribution['Status'] = 'Deployed'
           end
 
-          etag = Fog::CDN::AWS::Mock.generic_id
+          etag = Fog::AWS::CDN::Mock.generic_id
           response.status = 200
           response.body = distribution.reject { |k,v| k == 'ETag' }
 

--- a/lib/fog/aws/requests/cdn/get_streaming_distribution_list.rb
+++ b/lib/fog/aws/requests/cdn/get_streaming_distribution_list.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/get_streaming_distribution_list'
 
@@ -42,7 +42,7 @@ module Fog
             :expects    => 200,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::CDN::AWS::GetStreamingDistributionList.new,
+            :parser   => Fog::Parsers::AWS::CDN::GetStreamingDistributionList.new,
             :path       => "/streaming-distribution",
             :query      => options
           })

--- a/lib/fog/aws/requests/cdn/post_distribution.rb
+++ b/lib/fog/aws/requests/cdn/post_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/distribution'
 
@@ -77,7 +77,7 @@ module Fog
             :headers    => { 'Content-Type' => 'text/xml' },
             :idempotent => true,
             :method     => 'POST',
-            :parser     => Fog::Parsers::CDN::AWS::Distribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::Distribution.new,
             :path       => "/distribution"
           })
         end
@@ -88,7 +88,7 @@ module Fog
 
         def post_distribution(options = {})
           if self.data[:distributions].values.any? { |d| (d['CNAME'] & (options['CNAME']||[])).empty? }
-            Fog::CDN::AWS::Mock.error(:invalid_argument, 'CNAME is already in use')
+            Fog::AWS::CDN::Mock.error(:invalid_argument, 'CNAME is already in use')
           end
 
           response = Excon::Response.new
@@ -96,10 +96,10 @@ module Fog
           response.status = 201
           options['CallerReference'] = Time.now.to_i.to_s
 
-          dist_id = Fog::CDN::AWS::Mock.distribution_id
+          dist_id = Fog::AWS::CDN::Mock.distribution_id
 
           distribution = {
-            'DomainName' => Fog::CDN::AWS::Mock.domain_name,
+            'DomainName' => Fog::AWS::CDN::Mock.domain_name,
             'Id' => dist_id,
             'Status' => 'InProgress',
             'LastModifiedTime' => Time.now.utc.iso8601,

--- a/lib/fog/aws/requests/cdn/post_invalidation.rb
+++ b/lib/fog/aws/requests/cdn/post_invalidation.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/post_invalidation'
 
@@ -35,7 +35,7 @@ module Fog
             :headers    => {'Content-Type' => 'text/xml'},
             :idempotent => true,
             :method     => 'POST',
-            :parser     => Fog::Parsers::CDN::AWS::PostInvalidation.new,
+            :parser     => Fog::Parsers::AWS::CDN::PostInvalidation.new,
             :path       => "/distribution/#{distribution_id}/invalidation"
           })
         end
@@ -45,7 +45,7 @@ module Fog
         def post_invalidation(distribution_id, paths, caller_reference = Time.now.to_i.to_s)
           distribution = self.data[:distributions][distribution_id]
           if distribution
-            invalidation_id = Fog::CDN::AWS::Mock.distribution_id
+            invalidation_id = Fog::AWS::CDN::Mock.distribution_id
             invalidation = {
               'Id' => invalidation_id,
               'Status' => 'InProgress',
@@ -66,7 +66,7 @@ module Fog
             response.body = invalidation
             response
           else
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
         end
       end

--- a/lib/fog/aws/requests/cdn/post_streaming_distribution.rb
+++ b/lib/fog/aws/requests/cdn/post_streaming_distribution.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/streaming_distribution'
 
@@ -64,7 +64,7 @@ module Fog
             :headers    => { 'Content-Type' => 'text/xml' },
             :idempotent => true,
             :method     => 'POST',
-            :parser     => Fog::Parsers::CDN::AWS::StreamingDistribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::StreamingDistribution.new,
             :path       => "/streaming-distribution"
           })
         end
@@ -75,7 +75,7 @@ module Fog
 
         def post_streaming_distribution(options = {})
           if self.data[:streaming_distributions].values.any? { |d| (d['CNAME'] & (options['CNAME']||[])).empty? }
-            Fog::CDN::AWS::Mock.error(:invalid_argument, 'CNAME is already in use')
+            Fog::AWS::CDN::Mock.error(:invalid_argument, 'CNAME is already in use')
           end
 
           response = Excon::Response.new
@@ -83,10 +83,10 @@ module Fog
           response.status = 201
           options['CallerReference'] = Time.now.to_i.to_s
 
-          dist_id = Fog::CDN::AWS::Mock.distribution_id
+          dist_id = Fog::AWS::CDN::Mock.distribution_id
 
           distribution = {
-            'DomainName' => Fog::CDN::AWS::Mock.domain_name,
+            'DomainName' => Fog::AWS::CDN::Mock.domain_name,
             'Id' => dist_id,
             'Status' => 'InProgress',
             'LastModifiedTime' => Time.now.utc.iso8601,

--- a/lib/fog/aws/requests/cdn/put_distribution_config.rb
+++ b/lib/fog/aws/requests/cdn/put_distribution_config.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/distribution'
 
@@ -80,7 +80,7 @@ module Fog
             },
             :idempotent => true,
             :method     => 'PUT',
-            :parser     => Fog::Parsers::CDN::AWS::Distribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::Distribution.new,
             :path       => "/distribution/#{distribution_id}/config"
           })
         end
@@ -92,10 +92,10 @@ module Fog
 
           if distribution
             if distribution['ETag'] != etag
-              Fog::CDN::AWS::Mock.error(:invalid_if_match_version)
+              Fog::AWS::CDN::Mock.error(:invalid_if_match_version)
             end
             unless distribution['DistributionConfig']['CallerReference']
-              Fog::CDN::AWS::Mock.error(:illegal_update)
+              Fog::AWS::CDN::Mock.error(:illegal_update)
             end
 
             distribution['DistributionConfig'].merge!(options)
@@ -103,11 +103,11 @@ module Fog
 
             response = Excon::Response.new
             response.status = 200
-            response.headers['ETag'] = Fog::CDN::AWS::Mock.generic_id
+            response.headers['ETag'] = Fog::AWS::CDN::Mock.generic_id
             response.body = distribution.merge({ 'LastModifiedTime' => Time.now.utc.iso8601 }).reject{ |k,v| k == 'ETag' }
             response
           else
-            Fog::CDN::AWS::Mock.error(:no_such_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_distribution)
           end
         end
       end

--- a/lib/fog/aws/requests/cdn/put_streaming_distribution_config.rb
+++ b/lib/fog/aws/requests/cdn/put_streaming_distribution_config.rb
@@ -1,6 +1,6 @@
 module Fog
-  module CDN
-    class AWS
+  module AWS
+    class CDN
       class Real
         require 'fog/aws/parsers/cdn/streaming_distribution'
 
@@ -69,7 +69,7 @@ module Fog
             },
             :idempotent => true,
             :method     => 'PUT',
-            :parser     => Fog::Parsers::CDN::AWS::StreamingDistribution.new,
+            :parser     => Fog::Parsers::AWS::CDN::StreamingDistribution.new,
             :path       => "/streaming-distribution/#{distribution_id}/config"
           })
         end
@@ -81,10 +81,10 @@ module Fog
 
           if distribution
             if distribution['ETag'] != etag
-              Fog::CDN::AWS::Mock.error(:invalid_if_match_version)
+              Fog::AWS::CDN::Mock.error(:invalid_if_match_version)
             end
             unless distribution['StreamingDistributionConfig']['CallerReference']
-              Fog::CDN::AWS::Mock.error(:illegal_update)
+              Fog::AWS::CDN::Mock.error(:illegal_update)
             end
 
             distribution['StreamingDistributionConfig'].merge!(options)
@@ -92,11 +92,11 @@ module Fog
 
             response = Excon::Response.new
             response.status = 200
-            response.headers['ETag'] = Fog::CDN::AWS::Mock.generic_id
+            response.headers['ETag'] = Fog::AWS::CDN::Mock.generic_id
             response.body = distribution.merge({ 'LastModifiedTime' => Time.now.utc.iso8601 }).reject{ |k,v| k == 'ETag' }
             response
           else
-            Fog::CDN::AWS::Mock.error(:no_such_streaming_distribution)
+            Fog::AWS::CDN::Mock.error(:no_such_streaming_distribution)
           end
         end
       end

--- a/lib/fog/aws/service_mapper.rb
+++ b/lib/fog/aws/service_mapper.rb
@@ -14,7 +14,7 @@ module Fog
           when :beanstalk
             Fog::AWS::ElasticBeanstalk
           when :cdn
-            Fog::CDN::AWS
+            Fog::AWS::CDN
           when :cloud_formation
             Fog::AWS::CloudFormation
           when :cloud_watch


### PR DESCRIPTION
Fixes fog-core deprecation warning

```
[fog][DEPRECATION] Unable to load Fog::AWS::CDN
[fog][DEPRECATION] The format Fog::CDN::AWS is deprecated
```

Part of https://github.com/fog/fog-aws/issues/466