### PR TITLE
Rename DNS::AWS to AWS::DNS

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -13,10 +13,6 @@ module Fog
     autoload :AWS, File.expand_path('../aws/compute', __FILE__)
   end
 
-  module DNS
-    autoload :AWS, File.expand_path('../aws/dns', __FILE__)
-  end
-
   module Storage
     autoload :AWS, File.expand_path('../aws/storage', __FILE__)
   end
@@ -35,6 +31,7 @@ module Fog
     autoload :CloudFormation,   File.expand_path('../aws/cloud_formation', __FILE__)
     autoload :CloudWatch,       File.expand_path('../aws/cloud_watch', __FILE__)
     autoload :DataPipeline,     File.expand_path('../aws/data_pipeline', __FILE__)
+    autoload :DNS,              File.expand_path('../aws/dns', __FILE__)
     autoload :DynamoDB,         File.expand_path('../aws/dynamodb', __FILE__)
     autoload :ECS,              File.expand_path('../aws/ecs', __FILE__)
     autoload :EFS,              File.expand_path('../aws/efs', __FILE__)

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -162,4 +162,17 @@ module Fog
       end
     end
   end
+
+  # @deprecated
+  module DNS
+    # @deprecated
+    class AWS < Fog::AWS::DNS
+      # @deprecated
+      # @overrides Fog::Service.new (from the fog-core gem)
+      def self.new(*)
+        Fog::Logger.deprecation 'Fog::DNS::AWS is deprecated, please use Fog::AWS::DNS.'
+        super
+      end
+    end
+  end
 end

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS < Fog::Service
+    class DNS < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -77,7 +77,7 @@ module Fog
         # :aws_secret_access_key in order to create a connection
         #
         # ==== Examples
-        #   dns = Fog::DNS::AWS.new(
+        #   dns = Fog::AWS::DNS.new(
         #     :aws_access_key_id => your_aws_access_key_id,
         #     :aws_secret_access_key => your_aws_secret_access_key
         #   )
@@ -147,9 +147,9 @@ module Fog
           else
             raise case match[:code]
             when 'NoSuchHostedZone', 'NoSuchChange' then
-              Fog::DNS::AWS::NotFound.slurp(error, match[:message])
+              Fog::AWS::DNS::NotFound.slurp(error, match[:message])
             else
-              Fog::DNS::AWS::Error.slurp(error, "#{match[:code]} => #{match[:message]}")
+              Fog::AWS::DNS::Error.slurp(error, "#{match[:code]} => #{match[:message]}")
             end
           end
         end

--- a/lib/fog/aws/models/dns/record.rb
+++ b/lib/fog/aws/models/dns/record.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Record < Fog::Model
         extend Fog::Deprecation

--- a/lib/fog/aws/models/dns/record.rb
+++ b/lib/fog/aws/models/dns/record.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Record < Fog::Model
         extend Fog::Deprecation
         deprecate :ip, :value

--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/dns/record'
 
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Records < Fog::Collection
         attribute :is_truncated,            :aliases => ['IsTruncated']

--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -15,7 +15,7 @@ module Fog
 
         attribute :zone
 
-        model Fog::DNS::AWS::Record
+        model Fog::AWS::DNS::Record
 
         def all(options = {})
           requires :zone
@@ -99,7 +99,7 @@ module Fog
               record
             end
           end.compact.first
-        rescue Fog::DNS::AWS::NotFound
+        rescue Fog::AWS::DNS::NotFound
           nil
         end
 

--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/dns/record'
 
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Records < Fog::Collection
         attribute :is_truncated,            :aliases => ['IsTruncated']
         attribute :max_items,               :aliases => ['MaxItems']

--- a/lib/fog/aws/models/dns/zone.rb
+++ b/lib/fog/aws/models/dns/zone.rb
@@ -2,7 +2,7 @@
 
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Zone < Fog::Model
         identity :id,                 :aliases => 'Id'
 

--- a/lib/fog/aws/models/dns/zone.rb
+++ b/lib/fog/aws/models/dns/zone.rb
@@ -1,7 +1,7 @@
 # require 'fog/aws/models/dns/records'
 
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Zone < Fog::Model
         identity :id,                 :aliases => 'Id'

--- a/lib/fog/aws/models/dns/zone.rb
+++ b/lib/fog/aws/models/dns/zone.rb
@@ -20,7 +20,7 @@ module Fog
 
         def records
           @records ||= begin
-            Fog::DNS::AWS::Records.new(
+            Fog::AWS::DNS::Records.new(
               :zone       => self,
               :service => service
             )

--- a/lib/fog/aws/models/dns/zones.rb
+++ b/lib/fog/aws/models/dns/zones.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/dns/zone'
 
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Zones < Fog::Collection
         attribute :marker,    :aliases => 'Marker'
         attribute :max_items, :aliases => 'MaxItems'

--- a/lib/fog/aws/models/dns/zones.rb
+++ b/lib/fog/aws/models/dns/zones.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/dns/zone'
 
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Zones < Fog::Collection
         attribute :marker,    :aliases => 'Marker'

--- a/lib/fog/aws/models/dns/zones.rb
+++ b/lib/fog/aws/models/dns/zones.rb
@@ -7,7 +7,7 @@ module Fog
         attribute :marker,    :aliases => 'Marker'
         attribute :max_items, :aliases => 'MaxItems'
 
-        model Fog::DNS::AWS::Zone
+        model Fog::AWS::DNS::Zone
 
         def all(options = {})
           options[:marker]   ||= marker unless marker.nil?
@@ -19,7 +19,7 @@ module Fog
         def get(zone_id)
           data = service.get_hosted_zone(zone_id).body
           new(data)
-        rescue Fog::DNS::AWS::NotFound
+        rescue Fog::AWS::DNS::NotFound
           nil
         end
       end

--- a/lib/fog/aws/parsers/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/parsers/dns/change_resource_record_sets.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class ChangeResourceRecordSets < Fog::Parsers::Base
           def reset
             @response = {}

--- a/lib/fog/aws/parsers/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/parsers/dns/change_resource_record_sets.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class ChangeResourceRecordSets < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/create_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class CreateHostedZone < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/create_hosted_zone.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class CreateHostedZone < Fog::Parsers::Base
           def reset
             @hosted_zone = {}

--- a/lib/fog/aws/parsers/dns/delete_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/delete_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class DeleteHostedZone < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/delete_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/delete_hosted_zone.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class DeleteHostedZone < Fog::Parsers::Base
           def reset
             @response = {}

--- a/lib/fog/aws/parsers/dns/get_change.rb
+++ b/lib/fog/aws/parsers/dns/get_change.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class GetChange < Fog::Parsers::Base
           def reset
             @response = {}

--- a/lib/fog/aws/parsers/dns/get_change.rb
+++ b/lib/fog/aws/parsers/dns/get_change.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class GetChange < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/get_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class GetHostedZone < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/parsers/dns/get_hosted_zone.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class GetHostedZone < Fog::Parsers::Base
           def reset
             @hosted_zone = {}

--- a/lib/fog/aws/parsers/dns/health_check.rb
+++ b/lib/fog/aws/parsers/dns/health_check.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class HealthCheck < Fog::Parsers::Base
           def reset
             @health_check = {}

--- a/lib/fog/aws/parsers/dns/health_check.rb
+++ b/lib/fog/aws/parsers/dns/health_check.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class HealthCheck < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/list_health_checks.rb
+++ b/lib/fog/aws/parsers/dns/list_health_checks.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class ListHealthChecks < Fog::Parsers::Base
           def reset
             @health_checks = []

--- a/lib/fog/aws/parsers/dns/list_health_checks.rb
+++ b/lib/fog/aws/parsers/dns/list_health_checks.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class ListHealthChecks < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/list_hosted_zones.rb
+++ b/lib/fog/aws/parsers/dns/list_hosted_zones.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class ListHostedZones < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/list_hosted_zones.rb
+++ b/lib/fog/aws/parsers/dns/list_hosted_zones.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class ListHostedZones < Fog::Parsers::Base
           def reset
             @hosted_zones = []

--- a/lib/fog/aws/parsers/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/parsers/dns/list_resource_record_sets.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module DNS
+    module AWS
       module AWS
         class ListResourceRecordSets < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/parsers/dns/list_resource_record_sets.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module DNS
         class ListResourceRecordSets < Fog::Parsers::Base
           def reset
             @resource_record = []

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
 
       def self.hosted_zone_for_alias_target(dns_name)

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
 
       def self.hosted_zone_for_alias_target(dns_name)
         hosted_zones = if dns_name.match(/^dualstack\./)

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -198,7 +198,7 @@ module Fog
           request({
             :body       => body,
             :idempotent => true,
-            :parser     => Fog::Parsers::DNS::AWS::ChangeResourceRecordSets.new,
+            :parser     => Fog::Parsers::AWS::DNS::ChangeResourceRecordSets.new,
             :expects    => 200,
             :method     => 'POST',
             :path       => "hostedzone/#{zone_id}/rrset"
@@ -302,10 +302,10 @@ module Fog
               }
               response
             else
-              raise Fog::DNS::AWS::Error.new("InvalidChangeBatch => #{errors.join(", ")}")
+              raise Fog::AWS::DNS::Error.new("InvalidChangeBatch => #{errors.join(", ")}")
             end
           else
-            raise Fog::DNS::AWS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist.")
+            raise Fog::AWS::DNS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist.")
           end
         end
       end

--- a/lib/fog/aws/requests/dns/create_health_check.rb
+++ b/lib/fog/aws/requests/dns/create_health_check.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/health_check'

--- a/lib/fog/aws/requests/dns/create_health_check.rb
+++ b/lib/fog/aws/requests/dns/create_health_check.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/health_check'
 

--- a/lib/fog/aws/requests/dns/create_health_check.rb
+++ b/lib/fog/aws/requests/dns/create_health_check.rb
@@ -55,7 +55,7 @@ module Fog
             :expects => 201,
             :method  => 'POST',
             :path    => 'healthcheck',
-            :parser  => Fog::Parsers::DNS::AWS::HealthCheck.new
+            :parser  => Fog::Parsers::AWS::DNS::HealthCheck.new
           })
         end
       end

--- a/lib/fog/aws/requests/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/create_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/create_hosted_zone'
 

--- a/lib/fog/aws/requests/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/create_hosted_zone.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/create_hosted_zone'

--- a/lib/fog/aws/requests/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/create_hosted_zone.rb
@@ -48,7 +48,7 @@ module Fog
 
           request({
             :body    => %Q{<?xml version="1.0" encoding="UTF-8"?><CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/#{@version}/"><Name>#{name}</Name>#{optional_tags}</CreateHostedZoneRequest>},
-            :parser  => Fog::Parsers::DNS::AWS::CreateHostedZone.new,
+            :parser  => Fog::Parsers::AWS::DNS::CreateHostedZone.new,
             :expects => 201,
             :method  => 'POST',
             :path    => "hostedzone"
@@ -102,7 +102,7 @@ module Fog
             }
             response
           else
-            raise Fog::DNS::AWS::Error.new("DelegationSetNotAvailable => Amazon Route 53 allows some duplication, but Amazon Route 53 has a maximum threshold of duplicated domains. This error is generated when you reach that threshold. In this case, the error indicates that too many hosted zones with the given domain name exist. If you want to create a hosted zone and Amazon Route 53 generates this error, contact Customer Support.")
+            raise Fog::AWS::DNS::Error.new("DelegationSetNotAvailable => Amazon Route 53 allows some duplication, but Amazon Route 53 has a maximum threshold of duplicated domains. This error is generated when you reach that threshold. In this case, the error indicates that too many hosted zones with the given domain name exist. If you want to create a hosted zone and Amazon Route 53 generates this error, contact Customer Support.")
           end
         end
       end

--- a/lib/fog/aws/requests/dns/delete_health_check.rb
+++ b/lib/fog/aws/requests/dns/delete_health_check.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         # This action deletes a health check.
         # http://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteHealthCheck.html

--- a/lib/fog/aws/requests/dns/delete_health_check.rb
+++ b/lib/fog/aws/requests/dns/delete_health_check.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         # This action deletes a health check.

--- a/lib/fog/aws/requests/dns/delete_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/delete_hosted_zone.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/delete_hosted_zone'

--- a/lib/fog/aws/requests/dns/delete_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/delete_hosted_zone.rb
@@ -24,7 +24,7 @@ module Fog
 
           request({
             :expects => 200,
-            :parser  => Fog::Parsers::DNS::AWS::DeleteHostedZone.new,
+            :parser  => Fog::Parsers::AWS::DNS::DeleteHostedZone.new,
             :method  => 'DELETE',
             :path    => "hostedzone/#{zone_id}"
           })
@@ -37,7 +37,7 @@ module Fog
         def delete_hosted_zone(zone_id)
           response = Excon::Response.new
           key = [zone_id, "/hostedzone/#{zone_id}"].find { |k| !self.data[:zones][k].nil? } ||
-            raise(Fog::DNS::AWS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone does not exist."))
+            raise(Fog::AWS::DNS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone does not exist."))
 
             change = {
               :id => Fog::AWS::Mock.change_id,

--- a/lib/fog/aws/requests/dns/delete_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/delete_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/delete_hosted_zone'
 

--- a/lib/fog/aws/requests/dns/get_change.rb
+++ b/lib/fog/aws/requests/dns/get_change.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/get_change'
 

--- a/lib/fog/aws/requests/dns/get_change.rb
+++ b/lib/fog/aws/requests/dns/get_change.rb
@@ -23,7 +23,7 @@ module Fog
 
           request({
             :expects => 200,
-            :parser  => Fog::Parsers::DNS::AWS::GetChange.new,
+            :parser  => Fog::Parsers::AWS::DNS::GetChange.new,
             :method  => 'GET',
             :path    => "change/#{change_id}"
           })
@@ -36,7 +36,7 @@ module Fog
           # find the record with matching change_id
           # records = data[:zones].values.map{|z| z[:records].values.map{|r| r.values}}.flatten
           change = self.data[:changes][change_id] ||
-            raise(Fog::DNS::AWS::NotFound.new("NoSuchChange => Could not find resource with ID: #{change_id}"))
+            raise(Fog::AWS::DNS::NotFound.new("NoSuchChange => Could not find resource with ID: #{change_id}"))
 
           response.status = 200
           submitted_at = Time.parse(change[:submitted_at])

--- a/lib/fog/aws/requests/dns/get_change.rb
+++ b/lib/fog/aws/requests/dns/get_change.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/get_change'

--- a/lib/fog/aws/requests/dns/get_health_check.rb
+++ b/lib/fog/aws/requests/dns/get_health_check.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/health_check'

--- a/lib/fog/aws/requests/dns/get_health_check.rb
+++ b/lib/fog/aws/requests/dns/get_health_check.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/health_check'
 

--- a/lib/fog/aws/requests/dns/get_health_check.rb
+++ b/lib/fog/aws/requests/dns/get_health_check.rb
@@ -30,7 +30,7 @@ module Fog
         def get_health_check(id)
           request({
             :expects => 200,
-            :parser  => Fog::Parsers::DNS::AWS::HealthCheck.new,
+            :parser  => Fog::Parsers::AWS::DNS::HealthCheck.new,
             :method  => 'GET',
             :path    => "healthcheck/#{id}"
           })

--- a/lib/fog/aws/requests/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/get_hosted_zone.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/get_hosted_zone'

--- a/lib/fog/aws/requests/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/get_hosted_zone.rb
@@ -29,7 +29,7 @@ module Fog
             :expects => 200,
             :idempotent => true,
             :method  => 'GET',
-            :parser  => Fog::Parsers::DNS::AWS::GetHostedZone.new,
+            :parser  => Fog::Parsers::AWS::DNS::GetHostedZone.new,
             :path    => "hostedzone/#{zone_id}"
           })
         end
@@ -51,7 +51,7 @@ module Fog
             }
             response
           else
-            raise Fog::DNS::AWS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist.")
+            raise Fog::AWS::DNS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist.")
           end
         end
       end

--- a/lib/fog/aws/requests/dns/get_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/get_hosted_zone.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/get_hosted_zone'
 

--- a/lib/fog/aws/requests/dns/list_health_checks.rb
+++ b/lib/fog/aws/requests/dns/list_health_checks.rb
@@ -26,7 +26,7 @@ module Fog
             :expects => 200,
             :method  => 'GET',
             :path    => "healthcheck",
-            :parser  => Fog::Parsers::DNS::AWS::ListHealthChecks.new
+            :parser  => Fog::Parsers::AWS::DNS::ListHealthChecks.new
           })
         end
       end

--- a/lib/fog/aws/requests/dns/list_health_checks.rb
+++ b/lib/fog/aws/requests/dns/list_health_checks.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/list_health_checks'

--- a/lib/fog/aws/requests/dns/list_health_checks.rb
+++ b/lib/fog/aws/requests/dns/list_health_checks.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/list_health_checks'
 

--- a/lib/fog/aws/requests/dns/list_hosted_zones.rb
+++ b/lib/fog/aws/requests/dns/list_hosted_zones.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/list_hosted_zones'

--- a/lib/fog/aws/requests/dns/list_hosted_zones.rb
+++ b/lib/fog/aws/requests/dns/list_hosted_zones.rb
@@ -38,7 +38,7 @@ module Fog
 
           request({
             :query   => parameters,
-            :parser  => Fog::Parsers::DNS::AWS::ListHostedZones.new,
+            :parser  => Fog::Parsers::AWS::DNS::ListHostedZones.new,
             :expects => 200,
             :method  => 'GET',
             :path    => "hostedzone"

--- a/lib/fog/aws/requests/dns/list_hosted_zones.rb
+++ b/lib/fog/aws/requests/dns/list_hosted_zones.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/list_hosted_zones'
 

--- a/lib/fog/aws/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/list_resource_record_sets.rb
@@ -51,7 +51,7 @@ module Fog
             :expects => 200,
             :idempotent => true,
             :method  => 'GET',
-            :parser  => Fog::Parsers::DNS::AWS::ListResourceRecordSets.new,
+            :parser  => Fog::Parsers::AWS::DNS::ListResourceRecordSets.new,
             :path    => "hostedzone/#{zone_id}/rrset",
             :query   => parameters
           })
@@ -64,7 +64,7 @@ module Fog
             tmp_records.push(record) if !record[:name].nil? && ( name.nil? || record[:name].gsub(zone[:name],"") >= name)
             record.each do |key,subr|
               if subr.is_a?(Hash) && key.is_a?(String) &&
-                key.start_with?(Fog::DNS::AWS::Mock::SET_PREFIX)
+                key.start_with?(Fog::AWS::DNS::Mock::SET_PREFIX)
                 if name.nil?
                   tmp_records.append(subr)
                 else
@@ -81,7 +81,7 @@ module Fog
           response = Excon::Response.new
 
           zone = self.data[:zones][zone_id] ||
-            raise(Fog::DNS::AWS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist."))
+            raise(Fog::AWS::DNS::NotFound.new("NoSuchHostedZone => A hosted zone with the specified hosted zone ID does not exist."))
 
           records = if options[:type]
                       records_type = zone[:records][options[:type]]

--- a/lib/fog/aws/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/list_resource_record_sets.rb
@@ -1,5 +1,5 @@
 module Fog
-  module DNS
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/dns/list_resource_record_sets'

--- a/lib/fog/aws/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/list_resource_record_sets.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class DNS
       class Real
         require 'fog/aws/parsers/dns/list_resource_record_sets'
 

--- a/lib/fog/aws/service_mapper.rb
+++ b/lib/fog/aws/service_mapper.rb
@@ -26,7 +26,7 @@ module Fog
           when :ddb, :dynamodb
             Fog::AWS::DynamoDB
           when :dns
-            Fog::DNS::AWS
+            Fog::AWS::DNS
           when :elasticache
             Fog::AWS::Elasticache
           when :elb

--- a/tests/requests/dns/change_resource_record_sets_tests.rb
+++ b/tests/requests/dns/change_resource_record_sets_tests.rb
@@ -1,8 +1,8 @@
 Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
   tests('success') do
     test('#elb_hosted_zone_mapping from DNS name') do
-      zone_id = Fog::DNS::AWS.hosted_zone_for_alias_target('arbitrary-sub-domain.eu-west-1.elb.amazonaws.com')
-      zone_id == Fog::DNS::AWS.elb_hosted_zone_mapping['eu-west-1']
+      zone_id = Fog::AWS::DNS.hosted_zone_for_alias_target('arbitrary-sub-domain.eu-west-1.elb.amazonaws.com')
+      zone_id == Fog::AWS::DNS.elb_hosted_zone_mapping['eu-west-1']
     end
   end
 
@@ -18,7 +18,7 @@ Shindo.tests('Fog::DNS[:aws] | change_resource_record_sets', ['aws', 'dns']) do
         }]
 
     version = '2013-04-01'
-    result = Fog::DNS::AWS.change_resource_record_sets_data('zone_id123', change_batch, version)
+    result = Fog::AWS::DNS.change_resource_record_sets_data('zone_id123', change_batch, version)
     doc = Nokogiri::XML(result)
 
     returns("https://route53.amazonaws.com/doc/#{version}/") { doc.namespaces['xmlns'] }


### PR DESCRIPTION
Fixes fog-core deprecation warning

```
[fog][DEPRECATION] Unable to load Fog::AWS::DNS
[fog][DEPRECATION] The format Fog::DNS::AWS is deprecated
```

Part of #466
