### PR TITLE
Rename Storage::AWS to AWS::Storage

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -17,10 +17,6 @@ module Fog
     autoload :AWS, File.expand_path('../aws/dns', __FILE__)
   end
 
-  module Storage
-    autoload :AWS, File.expand_path('../aws/storage', __FILE__)
-  end
-
   module AWS
     extend Fog::Provider
 
@@ -54,6 +50,7 @@ module Fog
     autoload :SNS,              File.expand_path('../aws/sns', __FILE__)
     autoload :SQS,              File.expand_path('../aws/sqs', __FILE__)
     autoload :STS,              File.expand_path('../aws/sts', __FILE__)
+    autoload :Storage,          File.expand_path('../aws/storage', __FILE__)
     autoload :Support,          File.expand_path('../aws/support', __FILE__)
     autoload :SimpleDB,         File.expand_path('../aws/simpledb', __FILE__)
 

--- a/lib/fog/aws/models/storage/directories.rb
+++ b/lib/fog/aws/models/storage/directories.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/storage/directory'
 
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Directories < Fog::Collection
         model Fog::Storage::AWS::Directory
 

--- a/lib/fog/aws/models/storage/directories.rb
+++ b/lib/fog/aws/models/storage/directories.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/storage/directory'
 
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Directories < Fog::Collection
         model Fog::Storage::AWS::Directory

--- a/lib/fog/aws/models/storage/directories.rb
+++ b/lib/fog/aws/models/storage/directories.rb
@@ -4,7 +4,7 @@ module Fog
   module AWS
     class Storage
       class Directories < Fog::Collection
-        model Fog::Storage::AWS::Directory
+        model Fog::AWS::Storage::Directory
 
         def all
           data = service.get_service.body['Buckets']

--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/storage/files'
 require 'fog/aws/models/storage/versions'
 
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Directory < Fog::Model
         VALID_ACLS = ['private', 'public-read', 'public-read-write', 'authenticated-read']

--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -3,7 +3,7 @@ require 'fog/aws/models/storage/versions'
 
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Directory < Fog::Model
         VALID_ACLS = ['private', 'public-read', 'public-read-write', 'authenticated-read']
 

--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -31,7 +31,7 @@ module Fog
         end
 
         def location
-          @location ||= (bucket_location || AWS::DEFAULT_REGION)
+          @location ||= (bucket_location || Storage::DEFAULT_REGION)
         end
 
         # NOTE: you can't change the region once the bucket is created

--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -40,7 +40,7 @@ module Fog
         end
 
         def files
-          @files ||= Fog::Storage::AWS::Files.new(:directory => self, :service => service)
+          @files ||= Fog::AWS::Storage::Files.new(:directory => self, :service => service)
         end
 
         def payer
@@ -67,7 +67,7 @@ module Fog
         end
 
         def versions
-          @versions ||= Fog::Storage::AWS::Versions.new(:directory => self, :service => service)
+          @versions ||= Fog::AWS::Storage::Versions.new(:directory => self, :service => service)
         end
 
         def public=(new_public)

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -240,11 +240,11 @@ module Fog
         end
 
         # File version if exists or creates new version.
-        # @return [Fog::Storage::AWS::Version]
+        # @return [Fog::AWS::Storage::Version]
         #
         def versions
           @versions ||= begin
-            Fog::Storage::AWS::Versions.new(
+            Fog::AWS::Storage::Versions.new(
               :file         => self,
               :service   => service
             )

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/storage/versions'
 
 module Fog
   module AWS
-    class AWS
+    class Storage
       class File < Fog::Model
         # @see AWS Object docs http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectOps.html
 

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/storage/versions'
 
 module Fog
-  module Storage
+  module AWS
     class AWS
       class File < Fog::Model
         # @see AWS Object docs http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectOps.html

--- a/lib/fog/aws/models/storage/files.rb
+++ b/lib/fog/aws/models/storage/files.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/storage/file'
 
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Files < Fog::Collection
         extend Fog::Deprecation

--- a/lib/fog/aws/models/storage/files.rb
+++ b/lib/fog/aws/models/storage/files.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/storage/file'
 
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Files < Fog::Collection
         extend Fog::Deprecation
         deprecate :get_url, :get_https_url

--- a/lib/fog/aws/models/storage/files.rb
+++ b/lib/fog/aws/models/storage/files.rb
@@ -15,7 +15,7 @@ module Fog
         attribute :max_keys,        :aliases => ['MaxKeys', 'max-keys']
         attribute :prefix,          :aliases => 'Prefix'
 
-        model Fog::Storage::AWS::File
+        model Fog::AWS::Storage::File
 
         def all(options = {})
           requires :directory
@@ -70,7 +70,7 @@ module Fog
           when /<Code>NoSuchKey<\/Code>/
             nil
           when /<Code>NoSuchBucket<\/Code>/
-            raise(Fog::Storage::AWS::NotFound.new("Directory #{directory.identity} does not exist."))
+            raise(Fog::AWS::Storage::NotFound.new("Directory #{directory.identity} does not exist."))
           else
             raise(error)
           end

--- a/lib/fog/aws/models/storage/version.rb
+++ b/lib/fog/aws/models/storage/version.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Version < Fog::Model
         identity  :version,             :aliases => 'VersionId'
 

--- a/lib/fog/aws/models/storage/version.rb
+++ b/lib/fog/aws/models/storage/version.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Version < Fog::Model
         identity  :version,             :aliases => 'VersionId'

--- a/lib/fog/aws/models/storage/versions.rb
+++ b/lib/fog/aws/models/storage/versions.rb
@@ -2,7 +2,7 @@ require 'fog/aws/models/storage/version'
 
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Versions < Fog::Collection
         attribute :file
         attribute :directory

--- a/lib/fog/aws/models/storage/versions.rb
+++ b/lib/fog/aws/models/storage/versions.rb
@@ -1,7 +1,7 @@
 require 'fog/aws/models/storage/version'
 
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Versions < Fog::Collection
         attribute :file

--- a/lib/fog/aws/models/storage/versions.rb
+++ b/lib/fog/aws/models/storage/versions.rb
@@ -7,7 +7,7 @@ module Fog
         attribute :file
         attribute :directory
 
-        model Fog::Storage::AWS::Version
+        model Fog::AWS::Storage::Version
 
         def all(options = {})
           data = if file

--- a/lib/fog/aws/parsers/storage/access_control_list.rb
+++ b/lib/fog/aws/parsers/storage/access_control_list.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class AccessControlList < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/access_control_list.rb
+++ b/lib/fog/aws/parsers/storage/access_control_list.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class AccessControlList < Fog::Parsers::Base
           def reset
             @in_access_control_list = false

--- a/lib/fog/aws/parsers/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/parsers/storage/complete_multipart_upload.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class CompleteMultipartUpload < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/parsers/storage/complete_multipart_upload.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class CompleteMultipartUpload < Fog::Parsers::Base
           def reset
             @response = {}

--- a/lib/fog/aws/parsers/storage/copy_object.rb
+++ b/lib/fog/aws/parsers/storage/copy_object.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class CopyObject < Fog::Parsers::Base
           def end_element(name)
             case name

--- a/lib/fog/aws/parsers/storage/copy_object.rb
+++ b/lib/fog/aws/parsers/storage/copy_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class CopyObject < Fog::Parsers::Base
           def end_element(name)

--- a/lib/fog/aws/parsers/storage/cors_configuration.rb
+++ b/lib/fog/aws/parsers/storage/cors_configuration.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class CorsConfiguration < Fog::Parsers::Base
           def reset
             @in_cors_configuration_list = false

--- a/lib/fog/aws/parsers/storage/cors_configuration.rb
+++ b/lib/fog/aws/parsers/storage/cors_configuration.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class CorsConfiguration < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/parsers/storage/delete_multiple_objects.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class DeleteMultipleObjects < Fog::Parsers::Base
           def reset
             @deleted = { 'Deleted' => {} }

--- a/lib/fog/aws/parsers/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/parsers/storage/delete_multiple_objects.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class DeleteMultipleObjects < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucket < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucket < Fog::Parsers::Base
           def reset
             @object = { 'Owner' => {} }

--- a/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketLifecycle < Fog::Parsers::Base
           def reset
             @expiration = {}

--- a/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_lifecycle.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketLifecycle < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_location.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_location.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketLocation < Fog::Parsers::Base
           def end_element(name)

--- a/lib/fog/aws/parsers/storage/get_bucket_location.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_location.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketLocation < Fog::Parsers::Base
           def end_element(name)
             case name

--- a/lib/fog/aws/parsers/storage/get_bucket_logging.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_logging.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketLogging < Fog::Parsers::Base
           def reset
             @grant = { 'Grantee' => {} }

--- a/lib/fog/aws/parsers/storage/get_bucket_logging.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_logging.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketLogging < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_notification.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_notification.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketNotification < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_notification.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_notification.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketNotification < Fog::Parsers::Base
           def reset
             @func = {}

--- a/lib/fog/aws/parsers/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_object_versions.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketObjectVersions < Fog::Parsers::Base
           def reset
             @delete_marker = { 'Owner' => {} }

--- a/lib/fog/aws/parsers/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_object_versions.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketObjectVersions < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_tagging.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_tagging.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketTagging < Fog::Parsers::Base
           def reset
             @in_tag = {}

--- a/lib/fog/aws/parsers/storage/get_bucket_tagging.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_tagging.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketTagging < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_versioning.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetBucketVersioning < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_versioning.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetBucketVersioning < Fog::Parsers::Base
           def reset
             @response = { 'VersioningConfiguration' => {} }

--- a/lib/fog/aws/parsers/storage/get_bucket_website.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_website.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
 
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html

--- a/lib/fog/aws/parsers/storage/get_bucket_website.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_website.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
 
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html
         class GetBucketWebsite < Fog::Parsers::Base

--- a/lib/fog/aws/parsers/storage/get_request_payment.rb
+++ b/lib/fog/aws/parsers/storage/get_request_payment.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetRequestPayment < Fog::Parsers::Base
           def end_element(name)

--- a/lib/fog/aws/parsers/storage/get_request_payment.rb
+++ b/lib/fog/aws/parsers/storage/get_request_payment.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetRequestPayment < Fog::Parsers::Base
           def end_element(name)
             case name

--- a/lib/fog/aws/parsers/storage/get_service.rb
+++ b/lib/fog/aws/parsers/storage/get_service.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class GetService < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/get_service.rb
+++ b/lib/fog/aws/parsers/storage/get_service.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class GetService < Fog::Parsers::Base
           def reset
             @bucket = {}

--- a/lib/fog/aws/parsers/storage/initiate_multipart_upload.rb
+++ b/lib/fog/aws/parsers/storage/initiate_multipart_upload.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class InitiateMultipartUpload < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/initiate_multipart_upload.rb
+++ b/lib/fog/aws/parsers/storage/initiate_multipart_upload.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class InitiateMultipartUpload < Fog::Parsers::Base
           def reset
             @response = {}

--- a/lib/fog/aws/parsers/storage/list_multipart_uploads.rb
+++ b/lib/fog/aws/parsers/storage/list_multipart_uploads.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class ListMultipartUploads < Fog::Parsers::Base
           def reset
             @upload = { 'Initiator' => {}, 'Owner' => {} }

--- a/lib/fog/aws/parsers/storage/list_multipart_uploads.rb
+++ b/lib/fog/aws/parsers/storage/list_multipart_uploads.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class ListMultipartUploads < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/parsers/storage/list_parts.rb
+++ b/lib/fog/aws/parsers/storage/list_parts.rb
@@ -1,7 +1,7 @@
 module Fog
   module Parsers
     module AWS
-      module AWS
+      module Storage
         class ListParts < Fog::Parsers::Base
           def reset
             @part = {}

--- a/lib/fog/aws/parsers/storage/list_parts.rb
+++ b/lib/fog/aws/parsers/storage/list_parts.rb
@@ -1,6 +1,6 @@
 module Fog
   module Parsers
-    module Storage
+    module AWS
       module AWS
         class ListParts < Fog::Parsers::Base
           def reset

--- a/lib/fog/aws/requests/storage/abort_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/abort_multipart_upload.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         #

--- a/lib/fog/aws/requests/storage/abort_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/abort_multipart_upload.rb
@@ -25,7 +25,7 @@ module Fog
 
       class Mock # :nodoc:all
         require 'fog/aws/requests/storage/shared_mock_methods'
-        include Fog::Storage::AWS::SharedMockMethods
+        include Fog::AWS::Storage::SharedMockMethods
 
         def abort_multipart_upload(bucket_name, object_name, upload_id)
           verify_mock_bucket_exists(bucket_name)

--- a/lib/fog/aws/requests/storage/abort_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/abort_multipart_upload.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         #
         # Abort a multipart upload

--- a/lib/fog/aws/requests/storage/acl_utils.rb
+++ b/lib/fog/aws/requests/storage/acl_utils.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       require 'fog/aws/parsers/storage/access_control_list'
 

--- a/lib/fog/aws/requests/storage/acl_utils.rb
+++ b/lib/fog/aws/requests/storage/acl_utils.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       require 'fog/aws/parsers/storage/access_control_list'
 
       private

--- a/lib/fog/aws/requests/storage/acl_utils.rb
+++ b/lib/fog/aws/requests/storage/acl_utils.rb
@@ -51,7 +51,7 @@ module Fog
         end
 
         def self.acl_to_hash(acl_xml)
-          parser = Fog::Parsers::Storage::AWS::AccessControlList.new
+          parser = Fog::Parsers::AWS::Storage::AccessControlList.new
           Nokogiri::XML::SAX::Parser.new(parser).parse(acl_xml)
           parser.response
         end

--- a/lib/fog/aws/requests/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/complete_multipart_upload.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/complete_multipart_upload'

--- a/lib/fog/aws/requests/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/complete_multipart_upload.rb
@@ -40,7 +40,7 @@ module Fog
             :bucket_name => bucket_name,
             :object_name => object_name,
             :method     => 'POST',
-            :parser     => Fog::Parsers::Storage::AWS::CompleteMultipartUpload.new,
+            :parser     => Fog::Parsers::AWS::Storage::CompleteMultipartUpload.new,
             :query      => {'uploadId' => upload_id}
           })
         end
@@ -48,7 +48,7 @@ module Fog
 
       class Mock # :nodoc:all
         require 'fog/aws/requests/storage/shared_mock_methods'
-        include Fog::Storage::AWS::SharedMockMethods
+        include Fog::AWS::Storage::SharedMockMethods
 
         def complete_multipart_upload(bucket_name, object_name, upload_id, parts)
           bucket = verify_mock_bucket_exists(bucket_name)

--- a/lib/fog/aws/requests/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/complete_multipart_upload.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/complete_multipart_upload'
 

--- a/lib/fog/aws/requests/storage/copy_object.rb
+++ b/lib/fog/aws/requests/storage/copy_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/copy_object'
 

--- a/lib/fog/aws/requests/storage/copy_object.rb
+++ b/lib/fog/aws/requests/storage/copy_object.rb
@@ -35,7 +35,7 @@ module Fog
             :bucket_name => target_bucket_name,
             :object_name => target_object_name,
             :method   => 'PUT',
-            :parser   => Fog::Parsers::Storage::AWS::CopyObject.new,
+            :parser   => Fog::Parsers::AWS::Storage::CopyObject.new,
           })
         end
       end

--- a/lib/fog/aws/requests/storage/copy_object.rb
+++ b/lib/fog/aws/requests/storage/copy_object.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/copy_object'

--- a/lib/fog/aws/requests/storage/cors_utils.rb
+++ b/lib/fog/aws/requests/storage/cors_utils.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       require 'fog/aws/parsers/storage/cors_configuration'
 
       private

--- a/lib/fog/aws/requests/storage/cors_utils.rb
+++ b/lib/fog/aws/requests/storage/cors_utils.rb
@@ -30,7 +30,7 @@ module Fog
         end
 
         def self.cors_to_hash(cors_xml)
-          parser = Fog::Parsers::Storage::AWS::CorsConfiguration.new
+          parser = Fog::Parsers::AWS::Storage::CorsConfiguration.new
           Nokogiri::XML::SAX::Parser.new(parser).parse(cors_xml)
           parser.response
         end

--- a/lib/fog/aws/requests/storage/cors_utils.rb
+++ b/lib/fog/aws/requests/storage/cors_utils.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       require 'fog/aws/parsers/storage/cors_configuration'
 

--- a/lib/fog/aws/requests/storage/delete_bucket.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete an S3 bucket

--- a/lib/fog/aws/requests/storage/delete_bucket.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/delete_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_cors.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Deletes the cors configuration information set for the bucket.

--- a/lib/fog/aws/requests/storage/delete_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_cors.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Deletes the cors configuration information set for the bucket.
         #

--- a/lib/fog/aws/requests/storage/delete_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_lifecycle.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete lifecycle configuration for a bucket

--- a/lib/fog/aws/requests/storage/delete_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_lifecycle.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete lifecycle configuration for a bucket
         #

--- a/lib/fog/aws/requests/storage/delete_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_policy.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete policy for a bucket

--- a/lib/fog/aws/requests/storage/delete_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_policy.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete policy for a bucket
         #

--- a/lib/fog/aws/requests/storage/delete_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_tagging.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete tagging for a bucket

--- a/lib/fog/aws/requests/storage/delete_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_tagging.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete tagging for a bucket
         #

--- a/lib/fog/aws/requests/storage/delete_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_website.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete website configuration for a bucket

--- a/lib/fog/aws/requests/storage/delete_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/delete_bucket_website.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete website configuration for a bucket
         #

--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -56,7 +56,7 @@ module Fog
             :headers    => headers,
             :bucket_name => bucket_name,
             :method     => 'POST',
-            :parser     => Fog::Parsers::Storage::AWS::DeleteMultipleObjects.new,
+            :parser     => Fog::Parsers::AWS::Storage::DeleteMultipleObjects.new,
             :query      => {'delete' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/delete_multiple_objects'

--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/delete_multiple_objects'
 

--- a/lib/fog/aws/requests/storage/delete_object.rb
+++ b/lib/fog/aws/requests/storage/delete_object.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Delete an object from S3

--- a/lib/fog/aws/requests/storage/delete_object.rb
+++ b/lib/fog/aws/requests/storage/delete_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Delete an object from S3
         #

--- a/lib/fog/aws/requests/storage/delete_object_url.rb
+++ b/lib/fog/aws/requests/storage/delete_object_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module DeleteObjectUrl
         def delete_object_url(bucket_name, object_name, expires, options = {})

--- a/lib/fog/aws/requests/storage/delete_object_url.rb
+++ b/lib/fog/aws/requests/storage/delete_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module DeleteObjectUrl
         def delete_object_url(bucket_name, object_name, expires, options = {})
           unless bucket_name

--- a/lib/fog/aws/requests/storage/get_bucket.rb
+++ b/lib/fog/aws/requests/storage/get_bucket.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket'

--- a/lib/fog/aws/requests/storage/get_bucket.rb
+++ b/lib/fog/aws/requests/storage/get_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket'
 

--- a/lib/fog/aws/requests/storage/get_bucket.rb
+++ b/lib/fog/aws/requests/storage/get_bucket.rb
@@ -46,7 +46,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetBucket.new,
+            :parser   => Fog::Parsers::AWS::Storage::GetBucket.new,
             :query    => options
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/access_control_list'
 

--- a/lib/fog/aws/requests/storage/get_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_acl.rb
@@ -35,7 +35,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::AccessControlList.new,
+            :parser     => Fog::Parsers::AWS::Storage::AccessControlList.new,
             :query      => {'acl' => nil}
           })
         end
@@ -49,7 +49,7 @@ module Fog
           if acl = self.data[:acls][:bucket][bucket_name]
             response.status = 200
             if acl.is_a?(String)
-              response.body = Fog::Storage::AWS.acl_to_hash(acl)
+              response.body = Fog::AWS::Storage.acl_to_hash(acl)
             else
               response.body = acl
             end

--- a/lib/fog/aws/requests/storage/get_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_acl.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/access_control_list'

--- a/lib/fog/aws/requests/storage/get_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_cors.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/cors_configuration'
 

--- a/lib/fog/aws/requests/storage/get_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_cors.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/cors_configuration'

--- a/lib/fog/aws/requests/storage/get_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_cors.rb
@@ -31,7 +31,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::CorsConfiguration.new,
+            :parser     => Fog::Parsers::AWS::Storage::CorsConfiguration.new,
             :query      => {'cors' => nil}
           })
         end
@@ -45,7 +45,7 @@ module Fog
           if cors = self.data[:cors][:bucket][bucket_name]
             response.status = 200
             if cors.is_a?(String)
-              response.body = Fog::Storage::AWS.cors_to_hash(cors)
+              response.body = Fog::AWS::Storage.cors_to_hash(cors)
             else
               response.body = cors
             end

--- a/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_lifecycle'

--- a/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
@@ -25,7 +25,7 @@ module Fog
                     :bucket_name => bucket_name,
                     :idempotent => true,
                     :method   => 'GET',
-                    :parser   => Fog::Parsers::Storage::AWS::GetBucketLifecycle.new,
+                    :parser   => Fog::Parsers::AWS::Storage::GetBucketLifecycle.new,
                     :query    => {'lifecycle' => nil}
                   })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_lifecycle.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_lifecycle'
 

--- a/lib/fog/aws/requests/storage/get_bucket_location.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_location.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_location'
 

--- a/lib/fog/aws/requests/storage/get_bucket_location.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_location.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_location'

--- a/lib/fog/aws/requests/storage/get_bucket_location.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_location.rb
@@ -21,7 +21,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetBucketLocation.new,
+            :parser   => Fog::Parsers::AWS::Storage::GetBucketLocation.new,
             :query    => {'location' => nil},
             :path_style => true
           })

--- a/lib/fog/aws/requests/storage/get_bucket_logging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_logging.rb
@@ -35,7 +35,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::GetBucketLogging.new,
+            :parser     => Fog::Parsers::AWS::Storage::GetBucketLogging.new,
             :query      => {'logging' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_logging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_logging.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_logging'

--- a/lib/fog/aws/requests/storage/get_bucket_logging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_logging.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_logging'
 

--- a/lib/fog/aws/requests/storage/get_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_notification.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_notification'
 

--- a/lib/fog/aws/requests/storage/get_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_notification.rb
@@ -35,7 +35,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::GetBucketNotification.new,
+            :parser     => Fog::Parsers::AWS::Storage::GetBucketNotification.new,
             :query      => {'notification' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_notification.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_notification'

--- a/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_object_versions'
 

--- a/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
@@ -57,7 +57,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetBucketObjectVersions.new,
+            :parser   => Fog::Parsers::AWS::Storage::GetBucketObjectVersions.new,
             :query    => {'versions' => nil}.merge!(options)          })
         end
       end

--- a/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_object_versions.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_object_versions'

--- a/lib/fog/aws/requests/storage/get_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_policy.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Get bucket policy for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/get_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_policy.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Get bucket policy for an S3 bucket

--- a/lib/fog/aws/requests/storage/get_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_tagging.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_tagging'

--- a/lib/fog/aws/requests/storage/get_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_tagging.rb
@@ -25,7 +25,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::GetBucketTagging.new,
+            :parser     => Fog::Parsers::AWS::Storage::GetBucketTagging.new,
             :query      => {'tagging' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_tagging.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_tagging'
 

--- a/lib/fog/aws/requests/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_versioning.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_versioning'

--- a/lib/fog/aws/requests/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_versioning.rb
@@ -25,7 +25,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::GetBucketVersioning.new,
+            :parser     => Fog::Parsers::AWS::Storage::GetBucketVersioning.new,
             :query      => {'versioning' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_versioning.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_versioning'
 

--- a/lib/fog/aws/requests/storage/get_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_website.rb
@@ -28,7 +28,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::GetBucketWebsite.new,
+            :parser     => Fog::Parsers::AWS::Storage::GetBucketWebsite.new,
             :query      => {'website' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_website.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_bucket_website'
 

--- a/lib/fog/aws/requests/storage/get_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_website.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_bucket_website'

--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Get an object from S3

--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Get an object from S3
         #

--- a/lib/fog/aws/requests/storage/get_object_acl.rb
+++ b/lib/fog/aws/requests/storage/get_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/access_control_list'
 

--- a/lib/fog/aws/requests/storage/get_object_acl.rb
+++ b/lib/fog/aws/requests/storage/get_object_acl.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/access_control_list'

--- a/lib/fog/aws/requests/storage/get_object_acl.rb
+++ b/lib/fog/aws/requests/storage/get_object_acl.rb
@@ -46,7 +46,7 @@ module Fog
             :object_name => object_name,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::Parsers::Storage::AWS::AccessControlList.new,
+            :parser     => Fog::Parsers::AWS::Storage::AccessControlList.new,
             :query      => query
           })
         end
@@ -60,7 +60,7 @@ module Fog
           if acl = self.data[:acls][:object][bucket_name] && self.data[:acls][:object][bucket_name][object_name]
             response.status = 200
             if acl.is_a?(String)
-              response.body = Fog::Storage::AWS.acl_to_hash(acl)
+              response.body = Fog::AWS::Storage.acl_to_hash(acl)
             else
               response.body = acl
             end

--- a/lib/fog/aws/requests/storage/get_object_http_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_http_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module GetObjectHttpUrl
         def get_object_http_url(bucket_name, object_name, expires, options = {})
           get_object_url(bucket_name, object_name, expires, options.merge(:scheme => 'http'))

--- a/lib/fog/aws/requests/storage/get_object_http_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_http_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module GetObjectHttpUrl
         def get_object_http_url(bucket_name, object_name, expires, options = {})

--- a/lib/fog/aws/requests/storage/get_object_https_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_https_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module GetObjectHttpsUrl
         def get_object_https_url(bucket_name, object_name, expires, options = {})
           get_object_url(bucket_name, object_name, expires, options.merge(:scheme => 'https'))

--- a/lib/fog/aws/requests/storage/get_object_https_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_https_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module GetObjectHttpsUrl
         def get_object_https_url(bucket_name, object_name, expires, options = {})

--- a/lib/fog/aws/requests/storage/get_object_torrent.rb
+++ b/lib/fog/aws/requests/storage/get_object_torrent.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Get torrent for an S3 object

--- a/lib/fog/aws/requests/storage/get_object_torrent.rb
+++ b/lib/fog/aws/requests/storage/get_object_torrent.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Get torrent for an S3 object
         #

--- a/lib/fog/aws/requests/storage/get_object_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module GetObjectUrl
         def get_object_url(bucket_name, object_name, expires, options = {})

--- a/lib/fog/aws/requests/storage/get_object_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module GetObjectUrl
         def get_object_url(bucket_name, object_name, expires, options = {})
           unless bucket_name

--- a/lib/fog/aws/requests/storage/get_request_payment.rb
+++ b/lib/fog/aws/requests/storage/get_request_payment.rb
@@ -21,7 +21,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetRequestPayment.new,
+            :parser   => Fog::Parsers::AWS::Storage::GetRequestPayment.new,
             :query    => {'requestPayment' => nil}
           })
         end

--- a/lib/fog/aws/requests/storage/get_request_payment.rb
+++ b/lib/fog/aws/requests/storage/get_request_payment.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_request_payment'

--- a/lib/fog/aws/requests/storage/get_request_payment.rb
+++ b/lib/fog/aws/requests/storage/get_request_payment.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_request_payment'
 

--- a/lib/fog/aws/requests/storage/get_service.rb
+++ b/lib/fog/aws/requests/storage/get_service.rb
@@ -24,7 +24,7 @@ module Fog
             :host     => @host,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetService.new
+            :parser   => Fog::Parsers::AWS::Storage::GetService.new
           })
         end
       end

--- a/lib/fog/aws/requests/storage/get_service.rb
+++ b/lib/fog/aws/requests/storage/get_service.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/get_service'
 

--- a/lib/fog/aws/requests/storage/get_service.rb
+++ b/lib/fog/aws/requests/storage/get_service.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/get_service'

--- a/lib/fog/aws/requests/storage/head_bucket.rb
+++ b/lib/fog/aws/requests/storage/head_bucket.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Get headers for an S3 bucket, used to verify if it exists and if you have permission to access it

--- a/lib/fog/aws/requests/storage/head_bucket.rb
+++ b/lib/fog/aws/requests/storage/head_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Get headers for an S3 bucket, used to verify if it exists and if you have permission to access it
         #

--- a/lib/fog/aws/requests/storage/head_object.rb
+++ b/lib/fog/aws/requests/storage/head_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Get headers for an object from S3
         #

--- a/lib/fog/aws/requests/storage/head_object.rb
+++ b/lib/fog/aws/requests/storage/head_object.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Get headers for an object from S3

--- a/lib/fog/aws/requests/storage/head_object_url.rb
+++ b/lib/fog/aws/requests/storage/head_object_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module HeadObjectUrl
         def head_object_url(bucket_name, object_name, expires, options = {})

--- a/lib/fog/aws/requests/storage/head_object_url.rb
+++ b/lib/fog/aws/requests/storage/head_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module HeadObjectUrl
         def head_object_url(bucket_name, object_name, expires, options = {})
           unless bucket_name

--- a/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/initiate_multipart_upload'
 

--- a/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/initiate_multipart_upload'

--- a/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/initiate_multipart_upload.rb
@@ -32,7 +32,7 @@ module Fog
             :bucket_name => bucket_name,
             :object_name => object_name,
             :method     => 'POST',
-            :parser     => Fog::Parsers::Storage::AWS::InitiateMultipartUpload.new,
+            :parser     => Fog::Parsers::AWS::Storage::InitiateMultipartUpload.new,
             :query      => {'uploads' => nil}
           })
         end
@@ -40,7 +40,7 @@ module Fog
 
       class Mock # :nodoc:all
         require 'fog/aws/requests/storage/shared_mock_methods'
-        include Fog::Storage::AWS::SharedMockMethods
+        include Fog::AWS::Storage::SharedMockMethods
 
         def initiate_multipart_upload(bucket_name, object_name, options = {})
           verify_mock_bucket_exists(bucket_name)

--- a/lib/fog/aws/requests/storage/list_multipart_uploads.rb
+++ b/lib/fog/aws/requests/storage/list_multipart_uploads.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/list_multipart_uploads'
 

--- a/lib/fog/aws/requests/storage/list_multipart_uploads.rb
+++ b/lib/fog/aws/requests/storage/list_multipart_uploads.rb
@@ -42,7 +42,7 @@ module Fog
             :bucket_name => bucket_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::ListMultipartUploads.new,
+            :parser   => Fog::Parsers::AWS::Storage::ListMultipartUploads.new,
             :query    => options.merge!({'uploads' => nil})
           })
         end

--- a/lib/fog/aws/requests/storage/list_multipart_uploads.rb
+++ b/lib/fog/aws/requests/storage/list_multipart_uploads.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/list_multipart_uploads'

--- a/lib/fog/aws/requests/storage/list_parts.rb
+++ b/lib/fog/aws/requests/storage/list_parts.rb
@@ -43,7 +43,7 @@ module Fog
             :object_name => object_name,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::ListParts.new,
+            :parser   => Fog::Parsers::AWS::Storage::ListParts.new,
             :query    => options.merge!({'uploadId' => upload_id})
           })
         end

--- a/lib/fog/aws/requests/storage/list_parts.rb
+++ b/lib/fog/aws/requests/storage/list_parts.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/parsers/storage/list_parts'

--- a/lib/fog/aws/requests/storage/list_parts.rb
+++ b/lib/fog/aws/requests/storage/list_parts.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/parsers/storage/list_parts'
 

--- a/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
+++ b/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module PostObjectHiddenFields
         # Get a hash of hidden fields for form uploading to S3, in the form {:field_name => :field_value}

--- a/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
+++ b/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module PostObjectHiddenFields
         # Get a hash of hidden fields for form uploading to S3, in the form {:field_name => :field_value}
         # Form should look like: <form action="http://#{bucket_name}.s3.amazonaws.com/" method="post" enctype="multipart/form-data">

--- a/lib/fog/aws/requests/storage/post_object_restore.rb
+++ b/lib/fog/aws/requests/storage/post_object_restore.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Restore an object from Glacier to its original S3 path
         #

--- a/lib/fog/aws/requests/storage/post_object_restore.rb
+++ b/lib/fog/aws/requests/storage/post_object_restore.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Restore an object from Glacier to its original S3 path

--- a/lib/fog/aws/requests/storage/put_bucket.rb
+++ b/lib/fog/aws/requests/storage/put_bucket.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Create an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket.rb
+++ b/lib/fog/aws/requests/storage/put_bucket.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Create an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/requests/storage/acl_utils'
 

--- a/lib/fog/aws/requests/storage/put_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_acl.rb
@@ -29,7 +29,7 @@ module Fog
           headers = {}
 
           if acl.is_a?(Hash)
-            data = Fog::Storage::AWS.hash_to_acl(acl)
+            data = Fog::AWS::Storage.hash_to_acl(acl)
           else
             if !['private', 'public-read', 'public-read-write', 'authenticated-read'].include?(acl)
               raise Excon::Errors::BadRequest.new('invalid x-amz-acl')
@@ -55,7 +55,7 @@ module Fog
       class Mock
         def put_bucket_acl(bucket_name, acl)
           if acl.is_a?(Hash)
-            self.data[:acls][:bucket][bucket_name] = Fog::Storage::AWS.hash_to_acl(acl)
+            self.data[:acls][:bucket][bucket_name] = Fog::AWS::Storage.hash_to_acl(acl)
           else
             if !['private', 'public-read', 'public-read-write', 'authenticated-read'].include?(acl)
               raise Excon::Errors::BadRequest.new('invalid x-amz-acl')

--- a/lib/fog/aws/requests/storage/put_bucket_acl.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_acl.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/requests/storage/acl_utils'

--- a/lib/fog/aws/requests/storage/put_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_cors.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/requests/storage/cors_utils'

--- a/lib/fog/aws/requests/storage/put_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_cors.rb
@@ -19,7 +19,7 @@ module Fog
         # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketPUTcors.html
 
         def put_bucket_cors(bucket_name, cors)
-          data = Fog::Storage::AWS.hash_to_cors(cors)
+          data = Fog::AWS::Storage.hash_to_cors(cors)
 
           headers = {}
           headers['Content-MD5'] = Base64.encode64(OpenSSL::Digest::MD5.digest(data)).strip
@@ -39,7 +39,7 @@ module Fog
 
       class Mock
         def put_bucket_cors(bucket_name, cors)
-          self.data[:cors][:bucket][bucket_name] = Fog::Storage::AWS.hash_to_cors(cors)
+          self.data[:cors][:bucket][bucket_name] = Fog::AWS::Storage.hash_to_cors(cors)
         end
       end
     end

--- a/lib/fog/aws/requests/storage/put_bucket_cors.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_cors.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/requests/storage/cors_utils'
 

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change lifecycle configuration for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_lifecycle.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change lifecycle configuration for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_logging.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_logging.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change logging status for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_logging.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_logging.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change logging status for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_notification.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change notification configuration for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_notification.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_notification.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change notification configuration for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_policy.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change bucket policy for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_policy.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change bucket policy for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_tagging.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change tag set for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_tagging.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_tagging.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change tag set for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_versioning.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change versioning status for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_versioning.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change versioning status for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_website.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change website configuration for an S3 bucket

--- a/lib/fog/aws/requests/storage/put_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_website.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change website configuration for an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Create an object in an S3 bucket

--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -57,14 +57,14 @@ module Fog
 
       class Mock # :nodoc:all
         require 'fog/aws/requests/storage/shared_mock_methods'
-        include Fog::Storage::AWS::SharedMockMethods
+        include Fog::AWS::Storage::SharedMockMethods
 
         def put_object(bucket_name, object_name, data, options = {})
           define_mock_acl(bucket_name, object_name, options)
 
           data = parse_mock_data(data)
           headers = data[:headers].merge!(options)
-          Fog::Storage::AWS::Real.conforming_to_us_ascii! headers.keys.grep(/^x-amz-meta-/), headers
+          Fog::AWS::Storage::Real.conforming_to_us_ascii! headers.keys.grep(/^x-amz-meta-/), headers
           bucket = verify_mock_bucket_exists(bucket_name)
 
           options['Content-Type'] ||= data[:headers]['Content-Type']

--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Create an object in an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         require 'fog/aws/requests/storage/acl_utils'
 

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         require 'fog/aws/requests/storage/acl_utils'

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -37,7 +37,7 @@ module Fog
           headers = {}
 
           if acl.is_a?(Hash)
-            data = Fog::Storage::AWS.hash_to_acl(acl)
+            data = Fog::AWS::Storage.hash_to_acl(acl)
           else
             if !['private', 'public-read', 'public-read-write', 'authenticated-read'].include?(acl)
               raise Excon::Errors::BadRequest.new('invalid x-amz-acl')
@@ -64,7 +64,7 @@ module Fog
       class Mock
         def put_object_acl(bucket_name, object_name, acl, options = {})
           if acl.is_a?(Hash)
-            self.data[:acls][:object][bucket_name][object_name] = Fog::Storage::AWS.hash_to_acl(acl)
+            self.data[:acls][:object][bucket_name][object_name] = Fog::AWS::Storage.hash_to_acl(acl)
           else
             if !['private', 'public-read', 'public-read-write', 'authenticated-read'].include?(acl)
               raise Excon::Errors::BadRequest.new('invalid x-amz-acl')

--- a/lib/fog/aws/requests/storage/put_object_url.rb
+++ b/lib/fog/aws/requests/storage/put_object_url.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module PutObjectUrl
         def put_object_url(bucket_name, object_name, expires, headers = {}, options = {})

--- a/lib/fog/aws/requests/storage/put_object_url.rb
+++ b/lib/fog/aws/requests/storage/put_object_url.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module PutObjectUrl
         def put_object_url(bucket_name, object_name, expires, headers = {}, options = {})
           unless bucket_name

--- a/lib/fog/aws/requests/storage/put_request_payment.rb
+++ b/lib/fog/aws/requests/storage/put_request_payment.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Change who pays for requests to an S3 bucket
         #

--- a/lib/fog/aws/requests/storage/put_request_payment.rb
+++ b/lib/fog/aws/requests/storage/put_request_payment.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Change who pays for requests to an S3 bucket

--- a/lib/fog/aws/requests/storage/shared_mock_methods.rb
+++ b/lib/fog/aws/requests/storage/shared_mock_methods.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       module SharedMockMethods
         def define_mock_acl(bucket_name, object_name, options)

--- a/lib/fog/aws/requests/storage/shared_mock_methods.rb
+++ b/lib/fog/aws/requests/storage/shared_mock_methods.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       module SharedMockMethods
         def define_mock_acl(bucket_name, object_name, options)
           acl = options['x-amz-acl'] || 'private'

--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Sync clock against S3 to avoid skew errors
         #

--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Sync clock against S3 to avoid skew errors

--- a/lib/fog/aws/requests/storage/upload_part.rb
+++ b/lib/fog/aws/requests/storage/upload_part.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS
+    class Storage
       class Real
         # Upload a part for a multipart upload
         #

--- a/lib/fog/aws/requests/storage/upload_part.rb
+++ b/lib/fog/aws/requests/storage/upload_part.rb
@@ -37,7 +37,7 @@ module Fog
 
       class Mock # :nodoc:all
         require 'fog/aws/requests/storage/shared_mock_methods'
-        include Fog::Storage::AWS::SharedMockMethods
+        include Fog::AWS::Storage::SharedMockMethods
 
         def upload_part(bucket_name, object_name, upload_id, part_number, data, options = {})
           data = parse_mock_data(data)

--- a/lib/fog/aws/requests/storage/upload_part.rb
+++ b/lib/fog/aws/requests/storage/upload_part.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS
       class Real
         # Upload a part for a multipart upload

--- a/lib/fog/aws/service_mapper.rb
+++ b/lib/fog/aws/service_mapper.rb
@@ -46,7 +46,7 @@ module Fog
           when :sqs
             Fog::AWS::SQS
           when :eu_storage, :storage
-            Fog::Storage::AWS
+            Fog::AWS::Storage
           when :rds
             Fog::AWS::RDS
           when :sns

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -1,6 +1,6 @@
 module Fog
   module AWS
-    class AWS < Fog::Service
+    class Storage < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       COMPLIANT_BUCKET_NAMES = /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -764,4 +764,17 @@ DATA
       end
     end
   end
+
+  # @deprecated
+  module Storage
+    # @deprecated
+    class AWS < Fog::AWS::Storage
+      # @deprecated
+      # @overrides Fog::Service.new (from the fog-core gem)
+      def self.new(*)
+        Fog::Logger.deprecation 'Fog::Storage::AWS is deprecated, please use Fog::AWS::Storage.'
+        super
+      end
+    end
+  end
 end

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -1,5 +1,5 @@
 module Fog
-  module Storage
+  module AWS
     class AWS < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -130,7 +130,7 @@ module Fog
         end
 
         def url(params, expires)
-          Fog::Logger.deprecation("Fog::Storage::AWS => #url is deprecated, use #https_url instead [light_black](#{caller.first})[/]")
+          Fog::Logger.deprecation("Fog::AWS::Storage => #url is deprecated, use #https_url instead [light_black](#{caller.first})[/]")
           https_url(params, expires)
         end
 

--- a/tests/requests/storage/acl_utils_tests.rb
+++ b/tests/requests/storage/acl_utils_tests.rb
@@ -1,44 +1,44 @@
 require 'fog/aws/requests/storage/acl_utils'
 
-Shindo.tests('Fog::Storage::AWS | ACL utils', ["aws"]) do
+Shindo.tests('Fog::AWS::Storage | ACL utils', ["aws"]) do
   tests(".hash_to_acl") do
     tests(".hash_to_acl({}) at xpath //AccessControlPolicy").returns("", "has an empty AccessControlPolicy") do
-      xml = Fog::Storage::AWS.hash_to_acl({})
+      xml = Fog::AWS::Storage.hash_to_acl({})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy").first.content.chomp
     end
 
     tests(".hash_to_acl({}) at xpath //AccessControlPolicy/Owner").returns(nil, "does not have an Owner element") do
-      xml = Fog::Storage::AWS.hash_to_acl({})
+      xml = Fog::AWS::Storage.hash_to_acl({})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner").first
     end
 
     tests(".hash_to_acl('Owner' => {}) at xpath //AccessControlPolicy/Owner").returns(nil, "does not have an Owner element") do
-      xml = Fog::Storage::AWS.hash_to_acl('Owner' => {})
+      xml = Fog::AWS::Storage.hash_to_acl('Owner' => {})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner").first
     end
 
     tests(".hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'}) at xpath //AccessControlPolicy/Owner/ID").returns("abcdef0123456789", "returns the Owner ID") do
-      xml = Fog::Storage::AWS.hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'})
+      xml = Fog::AWS::Storage.hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner/ID").first.content
     end
 
     tests(".hash_to_acl('Owner' => {'DisplayName' => 'bob'}) at xpath //AccessControlPolicy/Owner/ID").returns(nil, "does not have an Owner ID element") do
-      xml = Fog::Storage::AWS.hash_to_acl('Owner' => {'DisplayName' => 'bob'})
+      xml = Fog::AWS::Storage.hash_to_acl('Owner' => {'DisplayName' => 'bob'})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner/ID").first
     end
 
     tests(".hash_to_acl('Owner' => {'DisplayName' => 'bob'}) at xpath //AccessControlPolicy/Owner/DisplayName").returns("bob", "returns the Owner DisplayName") do
-      xml = Fog::Storage::AWS.hash_to_acl('Owner' => {'DisplayName' => 'bob'})
+      xml = Fog::AWS::Storage.hash_to_acl('Owner' => {'DisplayName' => 'bob'})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner/DisplayName").first.content
     end
 
     tests(".hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'}) at xpath //AccessControlPolicy/Owner/DisplayName").returns(nil, "does not have an Owner DisplayName element") do
-      xml = Fog::Storage::AWS.hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'})
+      xml = Fog::AWS::Storage.hash_to_acl('Owner' => {'ID' => 'abcdef0123456789'})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/Owner/DisplayName").first
     end
 
     tests(".hash_to_acl({}) at xpath //AccessControlPolicy/AccessControlList").returns(nil, "has no AccessControlList") do
-      xml = Fog::Storage::AWS.hash_to_acl({})
+      xml = Fog::AWS::Storage.hash_to_acl({})
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlPolicy").first
     end
 
@@ -55,22 +55,22 @@ Shindo.tests('Fog::Storage::AWS | ACL utils', ["aws"]) do
     }
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee").returns("CanonicalUser", "has an xsi:type of CanonicalUser") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee").first.attributes["type"].value
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/ID").returns("abcdef0123456789", "returns the Grantee ID") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/ID").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/DisplayName").returns("bob", "returns the Grantee DisplayName") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/DisplayName").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Permission").returns("READ", "returns the Grantee Permission") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Permission").first.content
     end
 
@@ -86,17 +86,17 @@ Shindo.tests('Fog::Storage::AWS | ACL utils', ["aws"]) do
     }
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee").returns("AmazonCustomerByEmail", "has an xsi:type of AmazonCustomerByEmail") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee").first.attributes["type"].value
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/EmailAddress").returns("user@example.com", "returns the Grantee EmailAddress") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/EmailAddress").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Permission").returns("FULL_CONTROL", "returns the Grantee Permission") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Permission").first.content
     end
 
@@ -112,17 +112,17 @@ Shindo.tests('Fog::Storage::AWS | ACL utils', ["aws"]) do
     }
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee").returns("Group", "has an xsi:type of Group") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee").first.attributes["type"].value
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/URI").returns("http://acs.amazonaws.com/groups/global/AllUsers", "returns the Grantee URI") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/URI").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Permission").returns("WRITE", "returns the Grantee Permission") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Permission").first.content
     end
 
@@ -151,22 +151,22 @@ Shindo.tests('Fog::Storage::AWS | ACL utils', ["aws"]) do
     }
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant").returns(3, "has three elements") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant").size
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/ID").returns("abcdef0123456789", "returns the first Grant's Grantee ID") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/ID").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/EmailAddress").returns("user@example.com", "returns the second Grant's Grantee EmailAddress") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/EmailAddress").first.content
     end
 
     tests(".hash_to_acl(#{acl.inspect}) at xpath //AccessControlPolicy/AccessControlList/Grant/Grantee/URI").returns("http://acs.amazonaws.com/groups/global/AllUsers", "returns the third Grant's Grantee URI") do
-      xml = Fog::Storage::AWS.hash_to_acl(acl)
+      xml = Fog::AWS::Storage.hash_to_acl(acl)
       Nokogiri::XML(xml).xpath("//AccessControlPolicy/AccessControlList/Grant/Grantee/URI").first.content
     end
   end
@@ -203,7 +203,7 @@ XML
         "Permission" => "FULL_CONTROL"
       }]
     }, 'returns hash of ACL XML') do
-      Fog::Storage::AWS.acl_to_hash(acl_xml)
+      Fog::AWS::Storage.acl_to_hash(acl_xml)
     end
   end
 end

--- a/tests/requests/storage/cors_utils_tests.rb
+++ b/tests/requests/storage/cors_utils_tests.rb
@@ -1,14 +1,14 @@
 require 'fog/aws/requests/storage/cors_utils'
 
-Shindo.tests('Fog::Storage::AWS | CORS utils', ["aws"]) do
+Shindo.tests('Fog::AWS::Storage | CORS utils', ["aws"]) do
   tests(".hash_to_cors") do
     tests(".hash_to_cors({}) at xpath //CORSConfiguration").returns("", "has an empty CORSConfiguration") do
-      xml = Fog::Storage::AWS.hash_to_cors({})
+      xml = Fog::AWS::Storage.hash_to_cors({})
       Nokogiri::XML(xml).xpath("//CORSConfiguration").first.content.chomp
     end
 
     tests(".hash_to_cors({}) at xpath //CORSConfiguration/CORSRule").returns(nil, "has no CORSRules") do
-      xml = Fog::Storage::AWS.hash_to_cors({})
+      xml = Fog::AWS::Storage.hash_to_cors({})
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule").first
     end
 
@@ -26,52 +26,52 @@ Shindo.tests('Fog::Storage::AWS | CORS utils', ["aws"]) do
     }
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedOrigin").returns("origin_123", "returns the CORSRule AllowedOrigin") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedOrigin")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedOrigin").returns("origin_456", "returns the CORSRule AllowedOrigin") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedOrigin")[1].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedMethod").returns("GET", "returns the CORSRule AllowedMethod") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedMethod")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedMethod").returns("POST", "returns the CORSRule AllowedMethod") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedMethod")[1].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedHeader").returns("Accept", "returns the CORSRule AllowedHeader") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedHeader")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/AllowedHeader").returns("Content-Type", "returns the CORSRule AllowedHeader") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/AllowedHeader")[1].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/ID").returns("blah-888", "returns the CORSRule ID") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/ID")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/MaxAgeSeconds").returns("2500", "returns the CORSRule MaxAgeSeconds") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/MaxAgeSeconds")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/ExposeHeader").returns("x-some-header", "returns the CORSRule ExposeHeader") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/ExposeHeader")[0].content
     end
 
     tests(".hash_to_cors(#{cors.inspect}) at xpath //CORSConfiguration/CORSRule/ExposeHeader").returns("x-other-header", "returns the CORSRule ExposeHeader") do
-      xml = Fog::Storage::AWS.hash_to_cors(cors)
+      xml = Fog::AWS::Storage.hash_to_cors(cors)
       Nokogiri::XML(xml).xpath("//CORSConfiguration/CORSRule/ExposeHeader")[1].content
     end
   end
@@ -102,7 +102,7 @@ XML
         "ExposeHeader" => ["x-amz-server-side-encryption", "x-amz-balls"]
       }]
     }, 'returns hash of CORS XML') do
-      Fog::Storage::AWS.cors_to_hash(cors_xml)
+      Fog::AWS::Storage.cors_to_hash(cors_xml)
     end
   end
 end

--- a/tests/storage_tests.rb
+++ b/tests/storage_tests.rb
@@ -2,6 +2,6 @@
 
 Shindo.tests('AWS Storage | escape', ['aws']) do
   tests('Keys can contain a hierarchical prefix which should not be escaped') do
-    returns( Fog::Storage::AWS.new.send(:escape, "key/with/prefix") ) { "key/with/prefix" }
+    returns( Fog::AWS::Storage.new.send(:escape, "key/with/prefix") ) { "key/with/prefix" }
   end
 end


### PR DESCRIPTION
Fixes fog-core deprecation warning

```
[fog][DEPRECATION] Unable to load Fog::AWS::Storage
[fog][DEPRECATION] The format Fog::Storage::AWS is deprecated
```

Part of #466