### PR TITLE
Add missing generation 5 compute instance flavors

### DIFF
--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -85,6 +85,76 @@ module Fog
           :instance_store_volumes  => 0
         },
         {
+          :id                      => 't3.nano',
+          :name                    => 'T3 Nano',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 0,
+          :ram                     => 536,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.micro',
+          :name                    => 'T3 Micro',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 0,
+          :ram                     => 1073,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.small',
+          :name                    => 'T3 Small',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 0,
+          :ram                     => 2147,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.medium',
+          :name                    => 'T3 Medium',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 0,
+          :ram                     => 4294,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.large',
+          :name                    => 'T3 Large',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 0,
+          :ram                     => 8589,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.xlarge',
+          :name                    => 'T3 Extra Large',
+          :bits                    => 64,
+          :cores                   => 4,
+          :disk                    => 0,
+          :ram                     => 17179,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => 't3.2xlarge',
+          :name                    => 'T3 Double Extra Large',
+          :bits                    => 64,
+          :cores                   => 8,
+          :disk                    => 0,
+          :ram                     => 34359,
+          :ebs_optimized_available => false,
+          :instance_store_volumes  => 0
+        },
+        {
           :id                      => 'm1.small',
           :name                    => 'Small Instance',
           :bits                    => 32,

--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -375,6 +375,66 @@ module Fog
           :instance_store_volumes  => 0
         },
         {
+          :id                      => 'c5d.large',
+          :name                    => 'C5d Large',
+          :bits                    => 64,
+          :cores                   => 2,
+          :disk                    => 50,
+          :ram                     => 4294,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => 'c5d.xlarge',
+          :name                    => 'C5d Extra Large',
+          :bits                    => 64,
+          :cores                   => 4,
+          :disk                    => 100,
+          :ram                     => 8589,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => 'c5d.2xlarge',
+          :name                    => 'C5d Double Extra Large',
+          :bits                    => 64,
+          :cores                   => 8,
+          :disk                    => 200,
+          :ram                     => 17179,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => 'c5d.4xlarge',
+          :name                    => 'C5d Quadruple Extra Large',
+          :bits                    => 64,
+          :cores                   => 16,
+          :disk                    => 400,
+          :ram                     => 34359,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => 'c5d.9xlarge',
+          :name                    => 'C5d Nine Extra Large',
+          :bits                    => 64,
+          :cores                   => 36,
+          :disk                    => 900,
+          :ram                     => 77309,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => 'c5d.18xlarge',
+          :name                    => 'C5d Eighteen Extra Large',
+          :bits                    => 64,
+          :cores                   => 72,
+          :disk                    => 1800,
+          :ram                     => 154618,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 2
+        },
+        {
           :id                      => 'g2.2xlarge',
           :name                    => 'GPU Double Extra Large',
           :bits                    => 64,
@@ -883,6 +943,66 @@ module Fog
           :disk                    => 0,
           :ebs_optimized_available => true,
           :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "m5d.large",
+          :name                    => "M5d Large",
+          :bits                    => 64,
+          :cores                   => 2,
+          :ram                     => 8589,
+          :disk                    => 75,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "m5d.xlarge",
+          :name                    => "M5d Extra Large",
+          :bits                    => 64,
+          :cores                   => 4,
+          :ram                     => 17179,
+          :disk                    => 150,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "m5d.2xlarge",
+          :name                    => "M5d Double Extra Large",
+          :bits                    => 64,
+          :cores                   => 8,
+          :ram                     => 34359,
+          :disk                    => 300,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "m5d.4xlarge",
+          :name                    => "M5d Quadruple Extra Large",
+          :bits                    => 64,
+          :cores                   => 16,
+          :ram                     => 68719,
+          :disk                    => 600,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 2
+        },
+        {
+          :id                      => "m5d.12xlarge",
+          :name                    => "M5d Twelve Extra Large",
+          :bits                    => 64,
+          :cores                   => 48,
+          :ram                     => 206158,
+          :disk                    => 1800,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 2
+        },
+        {
+          :id                      => "m5d.24xlarge",
+          :name                    => "M5d Twenty Four Extra Large",
+          :bits                    => 64,
+          :cores                   => 96,
+          :ram                     => 412316,
+          :disk                    => 3600,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 4
         },
         {
           :id                      => "m4.16xlarge",

--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -91,7 +91,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 0,
           :ram                     => 536,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -101,7 +101,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 0,
           :ram                     => 1073,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -111,7 +111,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 0,
           :ram                     => 2147,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -121,7 +121,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 0,
           :ram                     => 4294,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -131,7 +131,7 @@ module Fog
           :cores                   => 2,
           :disk                    => 0,
           :ram                     => 8589,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -141,7 +141,7 @@ module Fog
           :cores                   => 4,
           :disk                    => 0,
           :ram                     => 17179,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {
@@ -151,7 +151,7 @@ module Fog
           :cores                   => 8,
           :disk                    => 0,
           :ram                     => 34359,
-          :ebs_optimized_available => false,
+          :ebs_optimized_available => true,
           :instance_store_volumes  => 0
         },
         {

--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -795,6 +795,126 @@ module Fog
           :instance_store_volumes  => 0
         },
         {
+          :id                      => "r5.large",
+          :name                    => "R5 Large",
+          :bits                    => 64,
+          :cores                   => 2,
+          :ram                     => 17179,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5.xlarge",
+          :name                    => "R5 Extra Large",
+          :bits                    => 64,
+          :cores                   => 4,
+          :ram                     => 34359,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5.2xlarge",
+          :name                    => "R5 Double Extra Large",
+          :bits                    => 64,
+          :cores                   => 8,
+          :ram                     => 68719,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5.4xlarge",
+          :name                    => "R5 Quadruple Extra Large",
+          :bits                    => 64,
+          :cores                   => 16,
+          :ram                     => 137438,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5.12xlarge",
+          :name                    => "R5 Twelve Extra Large",
+          :bits                    => 64,
+          :cores                   => 48,
+          :ram                     => 412316,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5.24xlarge",
+          :name                    => "R5 Twenty Four Extra Large",
+          :bits                    => 64,
+          :cores                   => 96,
+          :ram                     => 824633,
+          :disk                    => 0,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 0
+        },
+        {
+          :id                      => "r5d.large",
+          :name                    => "R5d Large",
+          :bits                    => 64,
+          :cores                   => 2,
+          :ram                     => 17179,
+          :disk                    => 75,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "r5d.xlarge",
+          :name                    => "R5d Extra Large",
+          :bits                    => 64,
+          :cores                   => 4,
+          :ram                     => 34359,
+          :disk                    => 150,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "r5d.2xlarge",
+          :name                    => "R5d Double Extra Large",
+          :bits                    => 64,
+          :cores                   => 8,
+          :ram                     => 68719,
+          :disk                    => 300,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 1
+        },
+        {
+          :id                      => "r5d.4xlarge",
+          :name                    => "R5d Quadruple Extra Large",
+          :bits                    => 64,
+          :cores                   => 16,
+          :ram                     => 137438,
+          :disk                    => 600,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 2
+        },
+        {
+          :id                      => "r5d.12xlarge",
+          :name                    => "R5d Twelve Extra Large",
+          :bits                    => 64,
+          :cores                   => 48,
+          :ram                     => 412316,
+          :disk                    => 1800,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 2
+        },
+        {
+          :id                      => "r5d.24xlarge",
+          :name                    => "R5d Twenty Four Extra Large",
+          :bits                    => 64,
+          :cores                   => 96,
+          :ram                     => 824633,
+          :disk                    => 3600,
+          :ebs_optimized_available => true,
+          :instance_store_volumes  => 4
+        },
+        {
           :id                      => "d2.xlarge",
           :name                    => "D2 Extra Large",
           :bits                    => 64,


### PR DESCRIPTION
Hi,

I've added missing generation 5 compute instance flavors: T3, M5d, C5d, R5, R5d.