### PR TITLE
Fixes/fog/aws/rds/ready

### DIFF
--- a/lib/fog/aws/models/rds/cluster.rb
+++ b/lib/fog/aws/models/rds/cluster.rb
@@ -23,7 +23,7 @@ module Fog
         attr_accessor :storage_encrypted #not in the response
 
         def ready?
-          state == "available"
+          state == "available" || state == 'active'
         end
 
         def snapshots

--- a/lib/fog/aws/models/rds/server.rb
+++ b/lib/fog/aws/models/rds/server.rb
@@ -55,7 +55,7 @@ module Fog
         end
 
         def ready?
-          state == 'available' || state == 'active'
+          state == 'available'
         end
 
         def destroy(snapshot_identifier=nil)

--- a/lib/fog/aws/models/rds/server.rb
+++ b/lib/fog/aws/models/rds/server.rb
@@ -55,7 +55,7 @@ module Fog
         end
 
         def ready?
-          state == 'available'
+          state == 'available' || state == 'active'
         end
 
         def destroy(snapshot_identifier=nil)


### PR DESCRIPTION
aws.rds.clusters.get('cluster_name').ready? gave false. Reason was in cluster.state which was "active" instead of "available"