### PR TITLE
Do not require access keys in Storage class

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -41,8 +41,7 @@ module Fog
         website
       ]
 
-      requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :instrumentor, :instrumentor_name, :aws_signature_version
+      recognizes :aws_access_key_id, :aws_secret_access_key, :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :instrumentor, :instrumentor_name, :aws_signature_version
 
       secrets    :aws_secret_access_key, :hmac
 


### PR DESCRIPTION
I wish to use an IAM profile for an instance to grant access to S3 buckets rather than pass in access keys.

This is possible throughout fog-aws by passing the `use_iam_profile`, but the `Storage` class requires aws_access_key_id and aws_secret_access_key parameters.

This causes errors related to malformed headers being submitted to Amazon S3 similar to being described in this issue. [1]

As suggested by the issue, workarounds such as passing in blank or bogus access keys do not resolve the issue.

The error is resolved by avoiding the necessity to pass in the access keys and only pass in the use_iam_profile parameter.

I cannot see an issue with not having an explicit require and I haven't updated any tests, but please let me know if I need to do further work against it.

[1] https://github.com/fog/fog-aws/issues/423#issuecomment-367133454