### PR TITLE
Fix for Aurora Server Provisioning.

### DIFF
--- a/lib/fog/aws/models/rds/cluster.rb
+++ b/lib/fog/aws/models/rds/cluster.rb
@@ -23,7 +23,15 @@ module Fog
         attr_accessor :storage_encrypted #not in the response
 
         def ready?
-          state == "available" || state == 'active'
+          # [2019.01] I don't think this is going to work, at least not with Aurora
+          # clusters. In my testing, the state reported by Fog for an Aurora cluster
+          # is "active" as soon as the cluster is retrievable from AWS, and the
+          # value doesn't change after that. Contrast that with the AWS Console UI,
+          # which reports the cluster as "Creating" while it's being created. I don't
+          # know where Fog is getting the state value from, but I don't think it's
+          # correct, at least not for the purpose of knowing if the Cluster is ready
+          # to have individual instances added to it.
+          state == 'available' || state == 'active'
         end
 
         def snapshots

--- a/lib/fog/aws/models/rds/server.rb
+++ b/lib/fog/aws/models/rds/server.rb
@@ -118,14 +118,14 @@ module Fog
           else
             requires :engine
 
-            if engine == 'aurora'
+            if engine.start_with?('aurora')
               requires :cluster_id
-              self.flavor_id ||= 'db.r3.large'
+              self.flavor_id ||= 'db.r4.large'
             else
               requires :master_username
               requires :password
               requires :allocated_storage
-              self.flavor_id ||= 'db.m1.small'
+              self.flavor_id ||= 'db.m4.large'
             end
 
             data = service.create_db_instance(id, attributes_to_params)


### PR DESCRIPTION
1. A non-functional commit, just a comment. I'm not sure the commit from December adding in the check for 'active' in the ready? method of RDS::Cluster is going to work, specifically for Aurora clusters. Please see my comment.
2. Updated the check for the "aurora" engine value in RDS::Server to check if the value starts with "aurora" instead of equaling "aurora." Early versions of Aurora did use just "aurora" for the engine. But that changed when Aurora started supporting more than just MySQL.