### PR TITLE
Correct DynamoDB update_item method

### DIFF
--- a/lib/fog/aws/requests/dynamodb/update_item.rb
+++ b/lib/fog/aws/requests/dynamodb/update_item.rb
@@ -7,15 +7,15 @@ module Fog
         #
         # ==== Parameters
         # * 'table_name'<~String> - name of table for item
-        # * 'key'<~Hash> - list of elements to be updated and their value
+        # * 'key'<~Hash> - list of Key attributes
         #   {
         #     "ForumName": {"S": "Amazon DynamoDB"},
         #     "Subject": {"S": "Maximum number of items?"}
         #   }
         #
         # * 'options'<~Hash>:
-        #   * 'KeyConditionExpression'<~String> - the condition elements need to match
-        #   * 'ExpressionAttributeValues'<~Hash> - values to be used in the key condition expression
+        #   * 'UpdateExpression'<~String> - the expression that will update the item
+        #   * 'ExpressionAttributeValues'<~Hash> - values to be used in the update expression
         #   * 'ReturnValues'<~String> - data to return in %w{ALL_NEW ALL_OLD NONE UPDATED_NEW UPDATED_OLD}, defaults to NONE
         #
         # ==== Returns

--- a/lib/fog/aws/requests/dynamodb/update_item.rb
+++ b/lib/fog/aws/requests/dynamodb/update_item.rb
@@ -29,13 +29,14 @@ module Fog
           if deprecated_attribute_updates
             raise DeprecatedAttributeUpdates, "The `20111205` DynamoDB API is deprecated. You need to use `ExpressionAttributeValues` instead of `AttributeUpdates`."
             attribute_updates = options
-            options = deprecated_attribute_updates
+            options = deprecated_attribute_updates.merge(
+              'AttributeUpdates'  => attribute_updates,
+            )
           end
 
           body = {
             'Key'               => key,
             'TableName'         => table_name,
-            'AttributeUpdates'  => attribute_updates,
           }.merge(options)
 
           request(


### PR DESCRIPTION
1. The `AttributeUpdates` option is deprecated and should no longer be passed in by default, unless the deprecated behavior is requested.
2. Updated the documentation to reflect the current [AWS DynamoDB update_item](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/dynamo-example-update-table-item.html) documentation.