### PR TITLE
Fix some requests when S3 acceleration is enabled

### DIFF
--- a/lib/fog/aws/requests/storage/get_bucket_location.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_location.rb
@@ -12,7 +12,7 @@ module Fog
         #   * body [Hash]:
         #     * LocationConstraint [String] - Location constraint of the bucket
         #
-        # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+        # @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
 
         def get_bucket_location(bucket_name)
           request({
@@ -22,8 +22,7 @@ module Fog
             :idempotent => true,
             :method   => 'GET',
             :parser   => Fog::Parsers::AWS::Storage::GetBucketLocation.new,
-            :query    => {'location' => nil},
-            :path_style => true
+            :query    => {'location' => nil}
           })
         end
       end

--- a/lib/fog/aws/requests/storage/get_service.rb
+++ b/lib/fog/aws/requests/storage/get_service.rb
@@ -15,13 +15,13 @@ module Fog
         #       * DisplayName [String] - Display name of bucket owner
         #       * ID [String] - Id of bucket owner
         #
-        # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTServiceGET.html
+        # @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
         #
         def get_service
           request({
             :expects  => 200,
             :headers  => {},
-            :host     => @host,
+            :host     => 's3.amazonaws.com',
             :idempotent => true,
             :method   => 'GET',
             :parser   => Fog::Parsers::AWS::Storage::GetService.new


### PR DESCRIPTION
This PR fixes some methods to make them work with acceleration enabled #505

+ get_bucket_location uses host instead of path_style

+ get_service explicitly uses s3.amazonaws.com as per docs https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html