### PR TITLE
Avoid using bucket_name.host if host is overriden.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -43,7 +43,7 @@ module Fog
       ]
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version
+      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version, :virtual_host, :cname
 
       secrets    :aws_secret_access_key, :hmac
 

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -292,7 +292,7 @@ module Fog
               if path_style
                 path = bucket_to_path bucket_name, path
               else
-                host = [bucket_name, host].join('.')
+                host = [bucket_name, host].join('.') unless params[:host]
               end
             end
           end

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -289,10 +289,14 @@ module Fog
                 end
               end
 
-              if path_style
+              # uses the bucket name as host if `virtual_host: true`, you can also
+              # manually specify the cname if required.
+              if params[:virtual_host]
+                host = params.fetch(:cname, bucket_name)
+              elsif path_style
                 path = bucket_to_path bucket_name, path
               else
-                host = [bucket_name, host].join('.') unless params[:host]
+                host = [bucket_name, host].join('.')
               end
             end
           end


### PR DESCRIPTION
In cases where you have CNAME pointing to the S3 bucket, implicitly combining the bucket name and overriden host prevents signed url generation with CNAME pointing to the bucket.  

This change fixes the issue. Potential gotcha is now you cannot override the hostname for region, but it should allow you to specify the exact hostname (along with bucket name) if needed.