### PR TITLE
Enhance/handle ELBv2 api version

### DIFF
--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -14,7 +14,7 @@ module Fog
       class ValidationError             < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
 
       request_path 'fog/aws/requests/elb'
       request :configure_health_check
@@ -142,6 +142,7 @@ module Fog
           @port       = options[:port]        || 443
           @scheme     = options[:scheme]      || 'https'
           @connection = Fog::XML::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
+          @version    = options[:version] || '2012-06-01'
 
           setup_credentials(options)
         end
@@ -178,7 +179,7 @@ module Fog
               :host               => @host,
               :path               => @path,
               :port               => @port,
-              :version            => '2012-06-01',
+              :version            => @version,
               :method             => 'POST'
           }
           )

--- a/lib/fog/aws/parsers/elb/describe_load_balancers.rb
+++ b/lib/fog/aws/parsers/elb/describe_load_balancers.rb
@@ -101,7 +101,8 @@ module Fog
                 @listener_description['Listener'][name] = value.to_i
               end
 
-            when 'CanonicalHostedZoneName', 'CanonicalHostedZoneNameID', 'LoadBalancerName', 'DNSName', 'Scheme'
+            when 'CanonicalHostedZoneName', 'CanonicalHostedZoneNameID', 'LoadBalancerName', 'DNSName', 'Scheme', 'Type', 'State',
+                 'LoadBalancerArn', 'IpAddressType', 'CanonicalHostedZoneId'
               @load_balancer[name] = value
             when 'CreatedTime'
               @load_balancer[name] = Time.parse(value)
@@ -119,9 +120,8 @@ module Fog
               @in_instances = false
             when 'InstanceId'
               @load_balancer['Instances'] << value
-            when 'VPCId'
+            when 'VPCId', 'VpcId'
               @load_balancer[name] = value
-
             when 'AvailabilityZones'
               @in_availability_zones = false
             when 'SecurityGroups'


### PR DESCRIPTION
Hello,

In this PR I added the possibility to choose the ELB service version and added some attributes on the describe_load_balancer parser corresponding to the newest version.
This changes was implemented to add the compatibility with "ELBv2" which is on the ELB api version ` 2015-12-01`.
- The documentation related to this version is here: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/Welcome.html
- You can also find the corresponding new LoadBalancer attributes here: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancer.html 

Thanks in advance for your time.