### PR TITLE
Removing path style as option as it should only be used with non DNS …

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -43,7 +43,7 @@ module Fog
       ]
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version, :virtual_host, :cname
+      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version, :virtual_host, :cname
 
       secrets    :aws_secret_access_key, :hmac
 
@@ -278,15 +278,13 @@ module Fog
             if params[:bucket_cname]
               host = bucket_name
             else
-              path_style = params.fetch(:path_style, @path_style)
-              if !path_style
-                if COMPLIANT_BUCKET_NAMES !~ bucket_name
-                  Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-                  path_style = true
-                elsif scheme == 'https' && !path_style && bucket_name =~ /\./
-                  Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-                  path_style = true
-                end
+              path_style = false
+              if COMPLIANT_BUCKET_NAMES !~ bucket_name
+                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance. For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                path_style = true
+              elsif scheme == 'https' && !path_style && bucket_name =~ /\./
+                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                path_style = true
               end
 
               # uses the bucket name as host if `virtual_host: true`, you can also
@@ -310,7 +308,6 @@ module Fog
           })
 
           #
-          ret.delete(:path_style)
           ret.delete(:bucket_name)
           ret.delete(:object_name)
           ret.delete(:region)
@@ -446,7 +443,6 @@ module Fog
           end
 
 
-          @path_style = options[:path_style] || false
           @signature_version = options.fetch(:aws_signature_version, 4)
           validate_signature_version!
           setup_credentials(options)
@@ -507,7 +503,6 @@ module Fog
           @acceleration = options.fetch(:acceleration, false)
           @signature_version = options.fetch(:aws_signature_version, 4)
           validate_signature_version!
-          @path_style = options[:path_style]  || false
 
           @region = options[:region] || DEFAULT_REGION
 


### PR DESCRIPTION
…compliant buckets

As a result of policy changes by AWS, accessing s3 using the path_style will only be supported for buckets created on or before 11/30/2020. As such this change removes the path_style as a configuration option but leaves in place safeguards to convert invalid bucket names to path_style calls.

#516 change discussed here
[updated announcement](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)
