### PR TITLE
Add support for generating tree hash tests by adding unaligned parts.

### DIFF
--- a/tests/requests/glacier/tree_hash_tests.rb
+++ b/tests/requests/glacier/tree_hash_tests.rb
@@ -59,14 +59,21 @@ Shindo.tests('AWS::Glacier | glacier tree hash calcuation', ['aws']) do
 
   end
 
+  # Aligned is used in general sense of https://en.wikipedia.org/wiki/Data_structure_alignment
+  # except we are not dealing with data in memory, but with parts in "virtual" space of whole file.
+  # Tests for https://github.com/fog/fog-aws/issues/520 and https://github.com/fog/fog-aws/issues/521
   tests('multipart with unaligned parts') do
     tree_hash = Fog::AWS::Glacier::TreeHash.new
     part = ('x' * 512*1024)
     returns(Fog::AWS::Glacier::TreeHash.digest(part)) { tree_hash.add_part part }
 
+    # At this point, we have 0.5MB in tree_hash. That means that the next part we add will not be aligned,
+    # because it will start on 0.5MB which is not 1MB boundary.
     part2 = ('x' * 512*1024) + ('y'*1024*1024) + ('z'* 512*1024)
     returns(Fog::AWS::Glacier::TreeHash.digest(part + part2)) { tree_hash.add_part part2 ; tree_hash.hexdigest }
 
+    # Here we are adding another 1.5MB to tree_hash which has size of 3.5MB. Again, 3.5MB is not on 1MB boundary,
+    # so this is another unaligned part. It does test different part of code, though.
     tree_hash.add_part('z'* 512*1024 + 't'*1024*1024)
 
     expected = OpenSSL::Digest::SHA256.hexdigest(


### PR DESCRIPTION
As discussed in #520 the previous Fog::AWS::Glacier::TreeHash::add_part works only in very specific and undocumented circumstances which are luckily exactly the ones actually happening when using the gem.
However, it's not that hard to make it work truly generally, replacing the list of digests by stack with one digest for every power of two and additional digest object with unfinished last chunk.
As additional bonus, it will reduce the amount of memory consumed when processing large files, although I doubt it will be relevant unless it will go into petabytes.