### PR TITLE
Update shared_mock_methods.rb

### DIFF
--- a/lib/fog/aws/requests/storage/shared_mock_methods.rb
+++ b/lib/fog/aws/requests/storage/shared_mock_methods.rb
@@ -4,7 +4,7 @@ module Fog
       module SharedMockMethods
         def define_mock_acl(bucket_name, object_name, options)
           acl = options['x-amz-acl'] || 'private'
-          if !['private', 'public-read', 'public-read-write', 'authenticated-read'].include?(acl)
+          if !['private', 'public-read', 'public-read-write', 'authenticated-read', 'bucket-owner-read', 'bucket-owner-full-control'].include?(acl)
             raise Excon::Errors::BadRequest.new('invalid x-amz-acl')
           else
             self.data[:acls][:object][bucket_name] ||= {}


### PR DESCRIPTION
Shouldn't this reflect the available acls from here https://www.rubydoc.info/gems/fog-aws/0.9.4/Fog/Storage/AWS/File#acl=-instance_method ?