### PR TITLE
Add ap-east-1 (Hong Kong) to Fog::AWS.regions

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -218,6 +218,7 @@ module Fog
 
     def self.regions
       @regions ||= [
+        'ap-east-1',
         'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
         'ap-south-1',
         'ap-southeast-1', 'ap-southeast-2',


### PR DESCRIPTION
As mentioned in #527 I simply added `ap-east-1` to the list of regions in `Fog::AWS.regions`. I also did some smoke tests with out AWS accounts for some EC2 and S3 API calls which just seem to work fine.

Please note, that `ap-east-1` (Hong Kong) is not enabled by default for every AWS account and you might need to enable it before you can use this regions (just in case someone wants to check this).

fixes #527