### PR TITLE
Fix VPC tenancy on creation

### DIFF
--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -106,7 +106,13 @@ module Fog
 
         def save
           requires :cidr_block
-          data = service.create_vpc(cidr_block, { 'AmazonProvidedIpv6CidrBlock' => amazon_provided_ipv_6_cidr_block }).body['vpcSet'].first
+
+          options = {
+            'AmazonProvidedIpv6CidrBlock' => amazon_provided_ipv_6_cidr_block,
+            'InstanceTenancy' => tenancy
+          }
+
+          data = service.create_vpc(cidr_block, options).body['vpcSet'].first
           new_attributes = data.reject {|key,value| key == 'requestId'}
           new_attributes = data.reject {|key,value| key == 'requestId' || key == 'tagSet' }
           merge_attributes(new_attributes)

--- a/lib/fog/aws/requests/compute/create_vpc.rb
+++ b/lib/fog/aws/requests/compute/create_vpc.rb
@@ -11,7 +11,6 @@ module Fog
         # * options<~Hash>:
         #   * InstanceTenancy<~String> - The allowed tenancy of instances launched into the VPC. A value of default
         #     means instances can be launched with any tenancy; a value of dedicated means instances must be launched with tenancy as dedicated.
-        #     please not that the documentation is incorrect instanceTenancy will not work while InstanceTenancy will
         #
         # === Returns
         # * response<~Excon::Response>:
@@ -54,7 +53,8 @@ module Fog
                 'classicLinkEnabled'          => false,
                 'classicLinkDnsSupport'       => false,
                 'cidrBlockAssociationSet'     => [{ 'cidrBlock' => cidrBlock, 'state' => 'associated', 'associationId' => "vpc-cidr-assoc-#{vpc_id}" }],
-                'ipv6CidrBlockAssociationSet' => []
+                'ipv6CidrBlockAssociationSet' => [],
+                'instanceTenancy'             => options['InstanceTenancy'] || 'default'
               }
               self.data[:vpcs].push(vpc)
 

--- a/tests/requests/compute/vpc_tests.rb
+++ b/tests/requests/compute/vpc_tests.rb
@@ -68,6 +68,12 @@ Shindo.tests('Fog::Compute[:aws] | vpc requests', ['aws']) do
       data
     end
 
+    tests("#create_vpc('10.255.254.0/28', {'InstanceTenancy' => 'dedicated'})").returns('dedicated') do
+      data = Fog::Compute[:aws].create_vpc('10.255.254.0/28',
+        {'InstanceTenancy' => 'dedicated'}).body
+      data['vpcSet'].first['instanceTenancy']
+    end
+
     tests('#describe_vpcs').formats(@describe_vpcs_format) do
       Fog::Compute[:aws].describe_vpcs.body
     end


### PR DESCRIPTION
**Bug:** 
When you try to create a VPC with tenancy set to dedicated like this:
`ec2.vpcs.create(cidr_block: request.cidr, tenancy: 'dedicated')`
the tenancy is set to "default" when the creation request is done.

**RC:**
VPC#save was not passing to create_vpc request the InstanceTenancy option.

**Fix:**
- Changed #save method to pass InstanceTenancy argument.
- Corrected mock response and added a test case.