### PR TITLE
Remove useless attribute location from directory model

### DIFF
--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -12,7 +12,6 @@ module Fog
         identity  :key,           :aliases => ['Name', 'name']
 
         attribute :creation_date, :aliases => 'CreationDate', :type => 'time'
-        attribute :location,      :aliases => 'LocationConstraint', :type => 'string'
 
         def acl=(new_acl)
           unless VALID_ACLS.include?(new_acl)


### PR DESCRIPTION
Hello,

A quick PR to remove `location`attribute from directory model, which is not usefull as:
- It's not an attributes from directories listing (https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html) (Fog use the API endpoint `GET service` but I didn't find it in the documentation and it have the same result than this one)
- It is implemented by a method which do the correct call to get it: https://github.com/fog/fog-aws/blob/master/lib/fog/aws/models/storage/directory.rb#L57-L64

Futhermore without this fix the behavior on pry is weird; The listing is long and the rendering is weird (event if the Fog object correctly respond to each attributes/methods):
*before*
```
[#<Fog::AWS::Storage::Directory:0x2ad1edfdc4f8>]
```
*after*
```
[
     <Fog::AWS::Storage::Directory
          key="alatestinventory",
          creation_date=2019-10-25 12:29:49 UTC
     >
]
```

Thanks in advance for your time.