### PR TITLE
Fix load balancers parser to handle more than one availability zone with addresses

### DIFF
--- a/lib/fog/aws/parsers/elbv2/describe_load_balancers.rb
+++ b/lib/fog/aws/parsers/elbv2/describe_load_balancers.rb
@@ -5,7 +5,7 @@ module Fog
         class DescribeLoadBalancers < Fog::Parsers::Base
           def reset
             reset_load_balancer
-            @availability_zone = { 'LoadBalancerAddresses' => [] }
+            reset_availability_zone
             @load_balancer_addresses = {}
             @state = {}
             @results = { 'LoadBalancers' => [] }
@@ -14,6 +14,10 @@ module Fog
 
           def reset_load_balancer
             @load_balancer = { 'SecurityGroups' => [], 'AvailabilityZones' => [] }
+          end
+
+          def reset_availability_zone
+            @availability_zone = { 'LoadBalancerAddresses' => [] }
           end
 
           def start_element(name, attrs = [])
@@ -37,7 +41,7 @@ module Fog
                 @availability_zone['LoadBalancerAddresses'] << @load_balancer_addresses
               elsif @in_availability_zones
                 @load_balancer['AvailabilityZones'] << @availability_zone
-                @availability_zone = {}
+                reset_availability_zone
               elsif @in_security_groups
                 @load_balancer['SecurityGroups'] << value
               else

--- a/tests/parsers/elbv2/describe_load_balancers_tests.rb
+++ b/tests/parsers/elbv2/describe_load_balancers_tests.rb
@@ -20,6 +20,12 @@ DESCRIBE_LOAD_BALANCERS_RESULT = <<-EOF
           <member>
             <SubnetId>subnet-b7d581c0</SubnetId>
             <ZoneName>us-west-2b</ZoneName>
+            <LoadBalancerAddresses>
+              <member>
+                <IpAddress>127.0.0.1</IpAddress>
+                <AllocationId>eipalloc-1c2ab192c131q2377</AllocationId>
+              </member>
+            </LoadBalancerAddresses>
           </member>
         </AvailabilityZones>
         <SecurityGroups>

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -6,7 +6,10 @@ class AWS
       }
 
       LOAD_BALANCER = {
-        "AvailabilityZones" => Array,
+        "AvailabilityZones" => [{
+          "SubnetId" => String, "ZoneName" => String,
+          "LoadBalancerAddresses" => [Fog::Nullable::Hash]
+        }],
         "LoadBalancerArn" => String,
         "DNSName" => String,
         "CreatedTime" => Time,


### PR DESCRIPTION
Hello,

In this PR I fix a little mistake of https://github.com/fog/fog-aws/pull/534;
The `availability_zone` attributes inside the parser was not correctly reset, then when an other `availability_zone` than the first one had an attribute `LoadBalancerAddresses` we had an error due to trying to adding an object inside a `nil` attributes of the `availability_zone` hash.

@geemus Sorry for this mistake !