### PR TITLE
Fix missed VpcId parsing in IpPermission which erase the vpcId of the security group

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_security_groups.rb
+++ b/lib/fog/aws/parsers/compute/describe_security_groups.rb
@@ -52,8 +52,12 @@ module Fog
                 end
               when 'groups'
                 @in_groups = false
-              when 'groupDescription', 'ownerId', 'vpcId'
+              when 'groupDescription', 'ownerId'
                 @security_group[name] = value
+              when 'vpcId'
+                unless @in_ip_permissions_egress || @in_ip_permissions
+                  @security_group[name] = value
+                end
               when 'groupId','groupName'
                 if @in_groups
                   @group[name] = value


### PR DESCRIPTION
Hello,

This PR fixed a little bug in the describe_security_groups parser;
Following AWS documentation, an IpPermission (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) could have an array of UserIdGroupPairs (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_UserIdGroupPair.html) which could have a field `vpcId`. As this value is listed later than the security group's `vpcId` and not handle in the parser, the vpcId value is erased.

This fix is a quick fix to ignore the invalid case, but to have a proper fix we will have to implement the UserIdGroupPairs object parsing inside the describe_security_groups parser.
I don't have time yet to do the proper fix unfortunally, but I can try to implement it in a near futur.

Thanks in advance for your time.