### PR TITLE
Adding two missing regions to Fog::AWS.regions

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -230,9 +230,11 @@ module Fog
         'eu-central-1',
         'eu-north-1',
         'eu-west-1', 'eu-west-2', 'eu-west-3',
+        'me-south-1',
         'us-east-1', 'us-east-2',
         'us-west-1', 'us-west-2',
         'sa-east-1',
+        'us-gov-east-1',
         'us-gov-west-1'
       ]
     end


### PR DESCRIPTION
Added the following to `lib/fog/aws.rb`
**me-south-1** - Middle East (Bahrain)
**us-gov-east-1** - AWS GovCloud (US) East

**NOTES**
1. **me-south-1** is not enabled by default for every AWS account and you might need to enable it before you can use this region
2. **us-gov-east-1** is part of AWS GovCloud (US)

