### PR TITLE
Don’t install development scripts

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
The scripts in `bin` appear intended for development, and have very generic names. They should not be installed as executables when installing the gem. Instead, change such executables to come from `exe`, which is more common.