### PR TITLE
Add support for IMDSv2 in CredentialFetcher

### DIFF
--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -7,6 +7,8 @@ Shindo.tests('AWS | credentials', ['aws']) do
   Fog.unmock!
   begin
     Excon.defaults[:mock] = true
+    Excon.stub({ method: :put, path: '/latest/api/token' }, { status: 200, body: 'token1234' })
+
     Excon.stub({ method: :get, path: '/latest/meta-data/iam/security-credentials/' }, { status: 200, body: 'arole' })
     Excon.stub({ method: :get, path: '/latest/meta-data/placement/availability-zone/' }, { status: 200, body: 'us-west-1a' })
 
@@ -62,6 +64,7 @@ Shindo.tests('AWS | credentials', ['aws']) do
 
     default_credentials = Fog::AWS::Compute.fetch_credentials({})
     tests('#fetch_credentials when the url 404s') do
+      Excon.stub({ method: :put, path: '/latest/api/token' }, { status: 404, body: 'not found' })
       Excon.stub({ method: :get, path: '/latest/meta-data/iam/security-credentials/' }, { status: 404, body: 'not bound' })
       Excon.stub({ method: :get, path: '/latest/meta-data/placement/availability-zone/' }, { status: 400, body: 'not found' })
       returns(default_credentials) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }


### PR DESCRIPTION
AWS has introduced [Instance Metadata Service Version 2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works) which improves security by moving to a session-oriented model that requires first retrieving a token via a `PUT` request that must be supplied with each `GET` request.

Currently, the gem throws an error if your EC2 instance is configured to only allow IMDSv2-based requests, which is recommended for maximum security.

IMDSv2 is supported by the metadata API without any configuration by the end-user, so switching the `CredentialFetcher` to use it improves security, fixes this error condition and should not have any negative effects for existing users.