### PR TITLE
Gracefully handle failure of IMDSv2 and allow fallback to IMDSv1

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -66,6 +66,9 @@ module Fog
             :expects => 200,
             :retry_interval => 1,
             :retry_limit => 3,
+            :read_timeout => 1,
+            :write_timeout => 1,
+            :connect_timeout => 1,
             :headers => { "X-aws-ec2-metadata-token-ttl-seconds" => "300" }
           ).body
 

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -30,6 +30,23 @@ Shindo.tests('AWS | credentials', ['aws']) do
               aws_credentials_expire_at: expires_at) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
     end
 
+    tests('#fetch_credentials when the v2 token 404s') do
+      Excon.stub({ method: :put, path: '/latest/api/token' }, { status: 404, body: 'not found' })
+      returns(aws_access_key_id: 'dummykey',
+              aws_secret_access_key: 'dummysecret',
+              aws_session_token: 'dummytoken',
+              region: 'us-west-1',
+              aws_credentials_expire_at: expires_at) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
+    end
+
+    tests('#fetch_credentials when the v2 disabled') do
+      returns(aws_access_key_id: 'dummykey',
+              aws_secret_access_key: 'dummysecret',
+              aws_session_token: 'dummytoken',
+              region: 'us-west-1',
+              aws_credentials_expire_at: expires_at) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true, disable_imds_v2: true) }
+    end
+
     ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/v1/credentials?id=task_id'
     Excon.stub({ method: :get, path: '/v1/credentials?id=task_id' }, { status: 200, body: Fog::JSON.encode(credentials) })
 


### PR DESCRIPTION
Fixes #560 

To address edge cases where the IMDSv2 API does not work for users, I have added support for the `CredentialFetcher` to fall-back to not using IMDSv2 tokens when the API call to retrieve the token fails 3 times, or when the option `:disable_imds_v2` is set to true. This is similar to the approach employed by [`aws-sdk-core`](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb).