### PR TITLE
Make it possible to pass in headers to head_object

### DIFF
--- a/lib/fog/aws/requests/storage/head_object.rb
+++ b/lib/fog/aws/requests/storage/head_object.rb
@@ -34,7 +34,7 @@ module Fog
           if version_id = options.delete('versionId')
             query = {'versionId' => version_id}
           end
-          headers = {}
+          headers = (options[:headers] || {}).dup
           headers['If-Modified-Since'] = Fog::Time.at(options['If-Modified-Since'].to_i).to_date_header if options['If-Modified-Since']
           headers['If-Unmodified-Since'] = Fog::Time.at(options['If-Unmodified-Since'].to_i).to_date_header if options['If-Modified-Since']
           headers.merge!(options)


### PR DESCRIPTION
For using AWS SSE-C, custom headers such as
`x-amz-server-side-encryption-customer-algorithm` and
`x-amz-server-side-encryption-customer-key` are needed to perform the
HEAD request.