### PR TITLE
S3 dot Region endpoint structure applied

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -227,7 +227,7 @@ module Fog
           when %r{\Acn-.*}
             "s3.#{region}.amazonaws.com.cn"
           else
-            "s3-#{region}.amazonaws.com"
+            "s3.#{region}.amazonaws.com"
           end
         end
 


### PR DESCRIPTION
Recommended style to generate endpoint is using dot instead of hyphen.
Please see: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html

> Virtual hosted style and path-style requests use the S3 dot Region endpoint structure (s3.Region), for example, https://my-bucket.s3.us-west-2.amazonaws.com. However, some older Amazon S3 Regions also support S3 dash Region endpoints s3-Region, for example, https://my-bucket.s3-us-west-2.amazonaws.com. If your bucket is in one of these Regions, you might see s3-Region endpoints in your server access logs or CloudTrail logs. We recommend that you do not use this endpoint structure in your requests.


