### PR TITLE
Add AssumeRoleWithWebIdentity to fetch_credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 group :test, :default do
   gem 'pry-nav'
   gem 'mime-types', '~> 3.1'
-  gem 'nokogiri', '~> 1.10.10'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :test, :default do
   gem 'pry-nav'
   gem 'mime-types', '~> 3.1'
+  gem 'nokogiri', '~> 1.10.10'
 end
 
 group :test do

--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "nokogiri"
-
 module Fog
   module AWS
     module CredentialFetcher


### PR DESCRIPTION
The action mentioned on the PR title can be found here: [AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Examples)

The `nokogiri` gem was added to parse the XML response from the host.