### PR TITLE
Add multi-threaded support for File#copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ directory.files
 directory.files.new(key: 'user/1/Gemfile').url(Time.now + 60)
 ```
 
+#### Copying a file
+
+```ruby
+directory = s3.directories.new(key: 'gaudi-portal-dev')
+file = directory.files.get('user/1/Gemfile')
+file.copy("target-bucket", "user/2/Gemfile.copy")
+```
+
+To speed transfers of large files, the `concurrency` option can be used
+to spawn multiple threads. Note that the file must be at least 5 MB for
+multipart uploads to work. For example:
+
+```ruby
+directory = s3.directories.new(key: 'gaudi-portal-dev')
+file = directory.files.get('user/1/Gemfile')
+file.multipart_chunk_size = 10 * 1024 * 1024
+file.concurrency = 10
+file.copy("target-bucket", "user/2/Gemfile.copy")
+```
+
 ## Documentation
 
 See the [online documentation](http://www.rubydoc.info/github/fog/fog-aws) for a complete API reference.

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -68,6 +68,17 @@ module Fog
           @multipart_chunk_size = mp_chunk_size
         end
 
+        # @note Number of threads used to copy files.
+        def concurrency=(concurrency)
+          raise ArgumentError.new('minimum concurrency is 1') if concurrency.to_i < 1
+
+          @concurrency = concurrency.to_i
+        end
+
+        def concurrency
+          @concurrency || 1
+        end
+
         def acl
           requires :directory, :key
           service.get_object_acl(directory.key, key).body['AccessControlList']
@@ -345,7 +356,7 @@ module Fog
           # Store ETags of upload parts
           part_tags = []
           pending = PartList.new(create_part_list(upload_part_options))
-          thread_count = options['concurrency'] || 1
+          thread_count = self.concurrency
           completed = PartList.new
           errors = upload_in_threads(target_directory_key, target_file_key, upload_id, pending, completed, thread_count)
 

--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -115,7 +115,7 @@ module Fog
           requires :directory, :key
 
           # With a single PUT operation you can upload objects up to 5 GB in size. Automatically set MP for larger objects.
-          self.multipart_chunk_size = MIN_MULTIPART_CHUNK_SIZE if !multipart_chunk_size && self.content_length.to_i > MAX_SINGLE_PUT_SIZE
+          self.multipart_chunk_size = MIN_MULTIPART_CHUNK_SIZE * 2 if !multipart_chunk_size && self.content_length.to_i > MAX_SINGLE_PUT_SIZE
 
           if multipart_chunk_size && self.content_length.to_i >= multipart_chunk_size
             upload_part_options = options.merge({ 'x-amz-copy-source' => "#{directory.key}/#{key}" })

--- a/tests/requests/storage/multipart_copy_tests.rb
+++ b/tests/requests/storage/multipart_copy_tests.rb
@@ -58,15 +58,19 @@ Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
 
     copied = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_copied_object')
 
+    test("concurrency defaults to 1") { file.concurrency == 1 }
     test("copied is the same") { copied.body == file.body }
   end
 
   tests('copies a file with many parts with 10 threads') do
     file = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_object')
     file.multipart_chunk_size = Fog::AWS::Storage::File::MIN_MULTIPART_CHUNK_SIZE
+    file.concurrency = 10
+
+    test("concurrency is set to 10") { file.concurrency == 10 }
 
     tests("#copy_object('#{@directory.identity}', 'copied_object_with_10_threads'").succeeds do
-      file.copy(@directory.identity, 'copied_object_with_10_threads', { concurrency: 10 })
+      file.copy(@directory.identity, 'copied_object_with_10_threads')
     end
 
     copied = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('copied_object_with_10_threads')

--- a/tests/requests/storage/multipart_copy_tests.rb
+++ b/tests/requests/storage/multipart_copy_tests.rb
@@ -3,6 +3,8 @@ require 'securerandom'
 Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
 
   @directory = Fog::Storage[:aws].directories.create(:key => uniq_id('fogmultipartcopytests'))
+  @large_data = SecureRandom.hex * 19 * 1024 * 1024
+  @large_blob = Fog::Storage[:aws].put_object(@directory.identity, 'large_object', @large_data)
 
   tests('copies an empty object') do
     Fog::Storage[:aws].put_object(@directory.identity, 'empty_object', '')
@@ -47,9 +49,6 @@ Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
   end
 
   tests('copies a file with many parts') do
-    data = SecureRandom.hex * 19 * 1024 * 1024
-    Fog::Storage[:aws].put_object(@directory.identity, 'large_object', data)
-
     file = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_object')
     file.multipart_chunk_size = Fog::AWS::Storage::File::MIN_MULTIPART_CHUNK_SIZE
 
@@ -58,6 +57,19 @@ Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
     end
 
     copied = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_copied_object')
+
+    test("copied is the same") { copied.body == file.body }
+  end
+
+  tests('copies a file with many parts with 10 threads') do
+    file = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_object')
+    file.multipart_chunk_size = Fog::AWS::Storage::File::MIN_MULTIPART_CHUNK_SIZE
+
+    tests("#copy_object('#{@directory.identity}', 'copied_object_with_10_threads'").succeeds do
+      file.copy(@directory.identity, 'copied_object_with_10_threads', { concurrency: 10 })
+    end
+
+    copied = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('copied_object_with_10_threads')
 
     test("copied is the same") { copied.body == file.body }
   end


### PR DESCRIPTION
This improves transfer performance significantly. For a 6 GB transfer, instead of taking several minutes to copy, it now appears to take 36 seconds on a local EC2 instance.