### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,41 @@ matrix:
     gemfile: gemfiles/Gemfile-edge
   - rvm: jruby-head
     gemfile: Gemfile
+# ppc64le specific changes
+  - rvm: 2.3.0
+    gemfile: Gemfile
+    arch: ppc64le
+  - rvm: 2.3.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.4.0
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.4.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.5.0
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.5.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.6.6
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.6.6
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.7.2
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.7.2
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: jruby-head
+    arch: ppc64le
+    gemfile: Gemfile
+    
   allow_failures:
   - rvm: jruby-head
     gemfile: Gemfile
@@ -43,6 +78,28 @@ matrix:
   - rvm: 2.6.6
     gemfile: gemfiles/Gemfile-edge
   - rvm: 2.7.2
+    gemfile: gemfiles/Gemfile-edge
+# ppc64le specific changes
+  - rvm: jruby-head
+    arch: ppc64le
+    gemfile: Gemfile
+  - rvm: 2.2.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.3.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.4.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.5.0
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.6.6
+    arch: ppc64le
+    gemfile: gemfiles/Gemfile-edge
+  - rvm: 2.7.2
+    arch: ppc64le
     gemfile: gemfiles/Gemfile-edge
 notifications:
   email: false


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/fog-aws/builds/208587510