### PR TITLE
Rewind pointer if file is eof on put_object mock

### DIFF
--- a/lib/fog/aws/requests/storage/shared_mock_methods.rb
+++ b/lib/fog/aws/requests/storage/shared_mock_methods.rb
@@ -15,6 +15,7 @@ module Fog
         def parse_mock_data(data)
           data = Fog::Storage.parse_data(data)
           unless data[:body].is_a?(String)
+            data[:body].rewind if data[:body].eof?
             data[:body] = data[:body].read
           end
           data

--- a/tests/requests/storage/object_tests.rb
+++ b/tests/requests/storage/object_tests.rb
@@ -18,6 +18,13 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file)
     end
 
+    tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file at EOF)").returns(lorem_file.read) do
+      file = lorem_file
+      file.read
+      Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', file)
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object').body
+    end
+
     tests("#copy_object('#{@directory.identity}', 'fog_object', '#{@directory.identity}', 'fog_other_object')").succeeds do
       Fog::Storage[:aws].copy_object(@directory.identity, 'fog_object', @directory.identity, 'fog_other_object')
     end


### PR DESCRIPTION
### What problem does this solve?
When passing a file object that has reached end-of-file to the `put_object` mock, an empty string is saved to the uploaded file body property. This is because subsequent `read` calls will return an empty string as there is no more to read. Sometimes code does some operations such as reading and validating a file before uploading to S3. The real service seems to be fine with the file being at EOF and still uploads the data, however I noticed the mocks are not

### How does this solve it?
Rewinds the pointer of the file object if the file is at EOF
