### PR TITLE
Fix NameError in multipart copy

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -360,7 +360,7 @@ module Fog
           completed = PartList.new
           errors = upload_in_threads(target_directory_key, target_file_key, upload_id, pending, completed, thread_count)
 
-          raise error.first if errors.any?
+          raise errors.first if errors.any?
 
           part_tags = completed.to_a.sort_by { |part| part.part_number }.map(&:etag)
         rescue => e


### PR DESCRIPTION
If an error occurred in a multipart copy, the following error would
show:

```
undefined local variable or method `error' for #<Fog::AWS::Storage::File:0x00007f98212f9d68>
Did you mean?  errors
```