### PR TITLE
Filter unknown UploadPartCopy paramaters

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -148,7 +148,8 @@ module Fog
           self.multipart_chunk_size = MIN_MULTIPART_CHUNK_SIZE * 2 if !multipart_chunk_size && self.content_length.to_i > MAX_SINGLE_PUT_SIZE
 
           if multipart_chunk_size && self.content_length.to_i >= multipart_chunk_size
-            upload_part_options = options.merge({ 'x-amz-copy-source' => "#{directory.key}/#{key}" })
+            upload_part_options = options.select { |key, _| ALLOWED_UPLOAD_PART_OPTIONS.include?(key.to_sym) }
+            upload_part_options = upload_part_options.merge({ 'x-amz-copy-source' => "#{directory.key}/#{key}" })
             multipart_copy(options, upload_part_options, target_directory_key, target_file_key)
           else
             service.copy_object(directory.key, key, target_directory_key, target_file_key, options)

--- a/lib/fog/aws/requests/storage/upload_part_copy.rb
+++ b/lib/fog/aws/requests/storage/upload_part_copy.rb
@@ -1,6 +1,25 @@
 module Fog
   module AWS
     class Storage
+      # From https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html
+      ALLOWED_UPLOAD_PART_OPTIONS = %i(
+        x-amz-copy-source
+        x-amz-copy-source-if-match
+        x-amz-copy-source-if-modified-since
+        x-amz-copy-source-if-none-match
+        x-amz-copy-source-if-unmodified-since
+        x-amz-copy-source-range
+        x-amz-copy-source-server-side-encryption-customer-algorithm
+        x-amz-copy-source-server-side-encryption-customer-key
+        x-amz-copy-source-server-side-encryption-customer-key-MD5
+        x-amz-expected-bucket-owner
+        x-amz-request-payer
+        x-amz-server-side-encryption-customer-algorithm
+        x-amz-server-side-encryption-customer-key
+        x-amz-server-side-encryption-customer-key-MD5
+        x-amz-source-expected-bucket-owner
+      ).freeze
+
       class Real
         require 'fog/aws/parsers/storage/upload_part_copy_object'
 
@@ -45,6 +64,8 @@ module Fog
         include Fog::AWS::Storage::SharedMockMethods
 
         def upload_part_copy(target_bucket_name, target_object_name, upload_id, part_number, options = {})
+          validate_options!(options)
+
           copy_source = options['x-amz-copy-source']
           copy_range = options['x-amz-copy-source-range']
 
@@ -85,6 +106,12 @@ module Fog
           end_pos = [matches[2].to_i, size].min
 
           [matches[1].to_i, end_pos]
+        end
+
+        def validate_options!(options)
+          options.keys.each do |key|
+            raise "Invalid UploadPart option: #{key}" unless ::Fog::AWS::Storage::ALLOWED_UPLOAD_PART_OPTIONS.include?(key.to_sym)
+          end
         end
       end # Mock
     end # Storage

--- a/tests/requests/storage/multipart_copy_tests.rb
+++ b/tests/requests/storage/multipart_copy_tests.rb
@@ -77,4 +77,17 @@ Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
 
     test("copied is the same") { copied.body == file.body }
   end
+
+  tests('copies an object with unknown headers') do
+    file = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('large_object')
+    file.multipart_chunk_size = Fog::AWS::Storage::File::MIN_MULTIPART_CHUNK_SIZE
+    file.concurrency = 10
+
+    tests("#copy_object('#{@directory.identity}', 'copied_object'").succeeds do
+      file.copy(@directory.identity, 'copied_object', { unknown: 1 } )
+    end
+
+    copied = Fog::Storage[:aws].directories.new(key: @directory.identity).files.get('copied_object')
+    test("copied is the same") { copied.body == file.body }
+  end
 end

--- a/tests/requests/storage/multipart_copy_tests.rb
+++ b/tests/requests/storage/multipart_copy_tests.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 Shindo.tests('Fog::Storage[:aws] | copy requests', ["aws"]) do
 
   @directory = Fog::Storage[:aws].directories.create(:key => uniq_id('fogmultipartcopytests'))
-  @large_data = SecureRandom.hex * 19 * 1024 * 1024
+  @large_data = SecureRandom.hex * 600000
   @large_blob = Fog::Storage[:aws].put_object(@directory.identity, 'large_object', @large_data)
 
   tests('copies an empty object') do


### PR DESCRIPTION
Previously attempting to use S3 server side encryption headers
(e.g. `x-amz-server-side-encryption`) would fail when attempting to use
`File#copy` because the method would pass these headers to the `UploadPartCopy`
(https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html)
API call. However, this would fail with an error:

```
<Code>InvalidArgument</Code>
<Message>x-amz-server-side-encryption header is not supported for this operation.</Message>
<ArgumentName>x-amz-server-side-encryption</ArgumentName>
<ArgumentValue>AES256</ArgumentValue>
```

This header can and should be used in the `CompleteMultipartUpload`
call. To support this, we filter out unknown headers in the
`UploadPartCopy`.