### PR TITLE
Enable test on Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     gemfile: Gemfile
   - rvm: 2.7.2
     gemfile: gemfiles/Gemfile-edge
+  - rvm: 3.0.0
+    gemfile: gemfiles/Gemfile-edge
   - rvm: jruby-head
     gemfile: Gemfile
 # ppc64le specific changes

--- a/tests/helpers/succeeds_helper.rb
+++ b/tests/helpers/succeeds_helper.rb
@@ -1,8 +1,8 @@
 module Shindo
   class Tests
-    def succeeds
+    def succeeds(&block)
       test('succeeds') do
-        !instance_eval(&Proc.new).nil?
+        !instance_eval(&Proc.new(&block)).nil?
       end
     end
   end


### PR DESCRIPTION
I am afraid there are some issues on Ruby 3.0, so this might not work right away. Also, not sure about the PPC64