### PR TITLE
Fixes domain name duplication in url

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -298,7 +298,7 @@ module Fog
                 host = params.fetch(:cname, bucket_name)
               elsif path_style
                 path = bucket_to_path bucket_name, path
-              else
+              elsif !host.include?(bucket_name)
                 host = [bucket_name, host].join('.')
               end
             end

--- a/tests/models/storage/directory_tests.rb
+++ b/tests/models/storage/directory_tests.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 Shindo.tests("Storage[:aws] | directory", ["aws"]) do
 
   directory_attributes = {
@@ -22,6 +24,21 @@ Shindo.tests("Storage[:aws] | directory", ["aws"]) do
       else
         @instance.public_url
       end
+    end
+  end
+
+  directory_attributes = {
+    :key => "fogdirectorytests-#{key=SecureRandom.hex(4)}",
+    :host => "fogdirectorytests-#{key}.s3.amazonaws.com",
+    :path_style => false
+  }
+
+  model_tests(Fog::Storage[:aws].directories, directory_attributes, Fog.mocking?) do
+    @instance.acl = 'public-read'
+    @instance.save
+
+    tests("#public_url does not duplicate bucket name in subdomain").returns(true) do
+      (@instance.public_url =~ %r[\Ahttps://fogdirectorytests-[\da-f]+\.s3\.amazonaws\.com/\z]) == 0
     end
   end
 

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -158,7 +158,7 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :IndexDocument => 'index.html')
     end
 
-    tests("#put_bucket_website('#{@aws_bucket_name}', :RedirectAllRequestsTo => 'redirect.example..com')").succeeds do
+    tests("#put_bucket_website('#{@aws_bucket_name}', :RedirectAllRequestsTo => 'redirect.example.com')").succeeds do
       Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :RedirectAllRequestsTo => 'redirect.example.com')
     end
 


### PR DESCRIPTION
When a bucket url like bucket.s3.amazonaws.com with bucket name bucket is present in params passed into request_params method,
It should not dupplicate the subdomain.

**current behaviour**: bucket.bucket.s3.amazonaws.com
**expected**: bucket.s3.amazonaws.com