### PR TITLE
Fixes domain name duplication in url

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -298,6 +298,8 @@ module Fog
                 host = params.fetch(:cname, bucket_name)
               elsif path_style
                 path = bucket_to_path bucket_name, path
+              elsif host.start_with?("#{bucket_name}.")
+                # no-op
               else
                 host = [bucket_name, host].join('.')
               end

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -158,7 +158,7 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :IndexDocument => 'index.html')
     end
 
-    tests("#put_bucket_website('#{@aws_bucket_name}', :RedirectAllRequestsTo => 'redirect.example..com')").succeeds do
+    tests("#put_bucket_website('#{@aws_bucket_name}', :RedirectAllRequestsTo => 'redirect.example.com')").succeeds do
       Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :RedirectAllRequestsTo => 'redirect.example.com')
     end
 


### PR DESCRIPTION
When a bucket url like `bucket.s3.amazonaws.com` with bucket name `bucket`is present in params passed into equest_params method, it should not duplicate the subdomain.

**current behavior**: bucket.bucket.s3.amazonaws.com
**expected behavior**: bucket.s3.amazonaws.com

Fixes: https://github.com/fog/fog-aws/issues/594