### PR TITLE
Generate a default session name if one is not provided

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 module Fog
   module AWS
     module CredentialFetcher
@@ -38,7 +40,7 @@ module Fog
                 params = {
                   :Action => "AssumeRoleWithWebIdentity",
                   :RoleArn => options[:role_arn] || ENV.fetch("AWS_ROLE_ARN"),
-                  :RoleSessionName => options[:role_session_name] || ENV.fetch("AWS_ROLE_SESSION_NAME"),
+                  :RoleSessionName => options[:role_session_name] || ENV["AWS_ROLE_SESSION_NAME"] || "fog-aws-#{SecureRandom.hex}",
                   :WebIdentityToken => File.read(options[:aws_web_identity_token_file] || ENV.fetch("AWS_WEB_IDENTITY_TOKEN_FILE")),
                   :Version => "2011-06-15",
                 }

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -87,6 +87,18 @@ Shindo.tests('AWS | credentials', ['aws']) do
       ) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
     end
 
+    ENV['AWS_ROLE_SESSION_NAME'] = nil
+
+    tests('#fetch_credentials token based without session name') do
+      returns(
+        aws_access_key_id: 'dummykey',
+        aws_secret_access_key: 'dummysecret',
+        aws_session_token: 'dummytoken',
+        region: 'us-west-1',
+        aws_credentials_expire_at: expires_at
+      ) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
+    end
+
     ENV['AWS_WEB_IDENTITY_TOKEN_FILE'] = nil
 
     compute = Fog::AWS::Compute.new(use_iam_profile: true)


### PR DESCRIPTION
When using IAM roles for Service Accounts (IRSA), annotated pods get a number of
environment variables:

1. `AWS_WEB_IDENTITY_TOKEN_FILE`
2. `AWS_ROLE_ARN`
3. `AWS_DEFAULT_REGION`
4. `AWS_REGION`

`AWS_ROLE_SESSION_NAME` is not usually included. The AWS SDK falls back
to using `default_name` as the default session name if
`AWS_ROLE_SESSION_NAME` is not provided. From
https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-role_session_name.html:

> If you don't provide this value, a session name is generated
> automatically if the profile assumes a role.