### PR TITLE
fix storage for ruby 3.0

### DIFF
--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -50,7 +50,7 @@ module Fog
 
           idempotent = true
           if block_given?
-            params[:response_block] = Proc.new
+            params[:response_block] = Proc.new(&block)
             idempotent = false
           end
 


### PR DESCRIPTION
adapt storage#get_object with a block given.  
ruby 3 raises an error when instantiating a proc without a block

@see https://blog.saeloun.com/2019/09/02/ruby-2-7-proc-without-block-warning.html