### PR TITLE
Do not use multipart copy for files smaller than 5GB

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -145,9 +145,9 @@ module Fog
           requires :directory, :key
 
           # With a single PUT operation you can upload objects up to 5 GB in size. Automatically set MP for larger objects.
-          self.multipart_chunk_size = MIN_MULTIPART_CHUNK_SIZE * 2 if !multipart_chunk_size && self.content_length.to_i > MAX_SINGLE_PUT_SIZE
+          if content_length.to_i > MAX_SINGLE_PUT_SIZE
+            self.multipart_chunk_size = MIN_MULTIPART_CHUNK_SIZE * 2 unless multipart_chunk_size
 
-          if multipart_chunk_size && self.content_length.to_i >= multipart_chunk_size
             upload_part_options = options.select { |key, _| ALLOWED_UPLOAD_PART_OPTIONS.include?(key.to_sym) }
             upload_part_options = upload_part_options.merge({ 'x-amz-copy-source' => "#{directory.key}/#{key}" })
             multipart_copy(options, upload_part_options, target_directory_key, target_file_key)


### PR DESCRIPTION
multipart_chunk_size is supposed to only set chunk size for multipart uploads.
It should not influence decision whether multipart upload will be used at all.

This change is supposed to speedup copying of files smaller than 5GB because they can be copied by a single efficient request with x-amz-copy-source