### PR TITLE
Add IPv6 support for Ingress Security Groups

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -233,21 +233,24 @@ module Fog
                         'fromPort'    => -1,
                         'toPort'      => -1,
                         'ipProtocol'  => 'icmp',
-                        'ipRanges'    => []
+                        'ipRanges'    => [],
+                        'ipv6Ranges'  => []
                       },
                       {
                         'groups'      => [{'groupName' => 'default', 'userId' => owner_id, 'groupId' => security_group_id}],
                         'fromPort'    => 0,
                         'toPort'      => 65535,
                         'ipProtocol'  => 'tcp',
-                        'ipRanges'    => []
+                        'ipRanges'    => [],
+                        'ipv6Ranges'  => []
                       },
                       {
                         'groups'      => [{'groupName' => 'default', 'userId' => owner_id, 'groupId' => security_group_id}],
                         'fromPort'    => 0,
                         'toPort'      => 65535,
                         'ipProtocol'  => 'udp',
-                        'ipRanges'    => []
+                        'ipRanges'    => [],
+                        'ipv6Ranges'  => []
                       }
                     ],
                     'ownerId'             => owner_id

--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -62,7 +62,8 @@ module Fog
         # options::
         #   A hash that can contain any of the following keys:
         #    :cidr_ip (defaults to "0.0.0.0/0")
-        #    :group - ("account:group_name" or "account:group_id"), cannot be used with :cidr_ip
+        #    :cidr_ipv6 cannot be used with :cidr_ip
+        #    :group - ("account:group_name" or "account:group_id"), cannot be used with :cidr_ip or :cidr_ipv6
         #    :ip_protocol (defaults to "tcp")
         #
         # == Returns:
@@ -178,7 +179,8 @@ module Fog
         # options::
         #   A hash that can contain any of the following keys:
         #    :cidr_ip (defaults to "0.0.0.0/0")
-        #    :group - ("account:group_name" or "account:group_id"), cannot be used with :cidr_ip
+        #    :cidr_ipv6 cannot be used with :cidr_ip
+        #    :group - ("account:group_name" or "account:group_id"), cannot be used with :cidr_ip or :cidr_ipv6
         #    :ip_protocol (defaults to "tcp")
         #
         # == Returns:
@@ -327,9 +329,15 @@ module Fog
           }
 
           if options[:group].nil?
-            ip_permission['IpRanges'] = [
-              { 'CidrIp' => options[:cidr_ip] || '0.0.0.0/0' }
-            ]
+            if options[:cidr_ipv6].nil?
+              ip_permission['IpRanges'] = [
+                { 'CidrIp' => options[:cidr_ip] || '0.0.0.0/0' }
+              ]
+            else
+              ip_permission['Ipv6Ranges'] = [
+                { 'CidrIpv6' => options[:cidr_ipv6] }
+              ]
+            end
           else
             ip_permission['Groups'] = [
               group_info(options[:group])

--- a/lib/fog/aws/parsers/compute/describe_security_groups.rb
+++ b/lib/fog/aws/parsers/compute/describe_security_groups.rb
@@ -5,9 +5,10 @@ module Fog
         class DescribeSecurityGroups < Fog::Parsers::Base
           def reset
             @group = {}
-            @ip_permission = { 'groups' => [], 'ipRanges' => []}
-            @ip_permission_egress = { 'groups' => [], 'ipRanges' => []}
+            @ip_permission = { 'groups' => [], 'ipRanges' => [], 'ipv6Ranges' => []}
+            @ip_permission_egress = { 'groups' => [], 'ipRanges' => [], 'ipv6Ranges' => []}
             @ip_range = {}
+            @ipv6_range = {}
             @security_group = { 'ipPermissions' => [], 'ipPermissionsEgress' => [], 'tagSet' => {} }
             @response = { 'securityGroupInfo' => [] }
             @tag = {}
@@ -24,6 +25,8 @@ module Fog
               @in_ip_permissions_egress = true
             when 'ipRanges'
               @in_ip_ranges = true
+            when 'ipv6Ranges'
+              @in_ipv6_ranges = true
             when 'tagSet'
               @in_tag_set = true
             end
@@ -44,6 +47,8 @@ module Fog
               case name
               when 'cidrIp'
                 @ip_range[name] = value
+              when 'cidrIpv6'
+                @ipv6_range[name] = value
               when 'fromPort', 'toPort'
                 if @in_ip_permissions_egress
                   @ip_permission_egress[name] = value.to_i
@@ -72,6 +77,8 @@ module Fog
                 end
               when 'ipRanges'
                 @in_ip_ranges = false
+              when 'ipv6Ranges'
+                @in_ipv6_ranges = false
               when 'item'
                 if @in_groups
                   if @in_ip_permissions_egress
@@ -87,12 +94,19 @@ module Fog
                     @ip_permission['ipRanges'] << @ip_range
                   end
                   @ip_range = {}
+                elsif @in_ipv6_ranges
+                  if @in_ip_permissions_egress
+                    @ip_permission_egress['ipv6Ranges'] << @ipv6_range
+                  else
+                    @ip_permission['ipv6Ranges'] << @ipv6_range
+                  end
+                  @ipv6_range = {}
                 elsif @in_ip_permissions
                   @security_group['ipPermissions'] << @ip_permission
-                  @ip_permission = { 'groups' => [], 'ipRanges' => []}
+                  @ip_permission = { 'groups' => [], 'ipRanges' => [], 'ipv6Ranges' => []}
                 elsif @in_ip_permissions_egress
                   @security_group['ipPermissionsEgress'] << @ip_permission_egress
-                  @ip_permission_egress = { 'groups' => [], 'ipRanges' => []}
+                  @ip_permission_egress = { 'groups' => [], 'ipRanges' => [], 'ipv6Ranges' => []}
                 else
                   @response['securityGroupInfo'] << @security_group
                   @security_group = { 'ipPermissions' => [], 'ipPermissionsEgress' => [], 'tagSet' => {} }

--- a/lib/fog/aws/requests/compute/authorize_security_group_ingress.rb
+++ b/lib/fog/aws/requests/compute/authorize_security_group_ingress.rb
@@ -30,6 +30,9 @@ module Fog
         #       * 'IpRanges'<~Array>:
         #         * ip_range<~Hash>:
         #           * 'CidrIp'<~String> - CIDR range
+        #       * 'Ipv6Ranges'<~Array>:
+        #         * ip_range<~Hash>:
+        #           * 'CidrIpv6'<~String> - CIDR range
         #       * 'ToPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
         #
         # === Returns
@@ -71,6 +74,10 @@ module Fog
             (permission['IpRanges'] || []).each_with_index do |ip_range, range_index|
               range_index += 1
               params[format('IpPermissions.%d.IpRanges.%d.CidrIp', key_index, range_index)] = ip_range['CidrIp']
+            end
+            (permission['Ipv6Ranges'] || []).each_with_index do |ip_range, range_index|
+              range_index += 1
+              params[format('IpPermissions.%d.Ipv6Ranges.%d.CidrIpv6', key_index, range_index)] = ip_range['CidrIpv6']
             end
           end
           params.reject {|k, v| v.nil? }
@@ -185,6 +192,14 @@ module Fog
               'toPort'     => Integer(options['ToPort']),
               'groups'     => [],
               'ipRanges'   => [{'cidrIp' => options['CidrIp']}]
+            }
+          elsif options['CidrIpv6']
+            normalized_permissions << {
+              'ipProtocol' => options['IpProtocol'],
+              'fromPort'   => Integer(options['FromPort']),
+              'toPort'     => Integer(options['ToPort']),
+              'groups'     => [],
+              'ipv6Ranges' => [{'cidrIpv6' => options['CidrIpv6']}]
             }
           elsif options['IpPermissions']
             options['IpPermissions'].each do |permission|

--- a/lib/fog/aws/requests/compute/describe_security_groups.rb
+++ b/lib/fog/aws/requests/compute/describe_security_groups.rb
@@ -27,6 +27,8 @@ module Fog
         #         * 'ipProtocol'<~String> - Ip protocol, must be in ['tcp', 'udp', 'icmp']
         #         * 'ipRanges'<~Array>:
         #           * 'cidrIp'<~String> - CIDR range
+        #         * 'ipv6Ranges'<~Array>:
+        #           * 'cidrIpv6'<~String> - CIDR ipv6 range
         #         * 'toPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
         #       * 'ownerId'<~String> - AWS Access Key Id of the owner of the security group
         #     * 'NextToken'<~String> - The token to retrieve the next page of results

--- a/tests/requests/compute/security_group_tests.rb
+++ b/tests/requests/compute/security_group_tests.rb
@@ -19,6 +19,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
         'groups'      => [{ 'groupName' => Fog::Nullable::String, 'userId' => String, 'groupId' => String }],
         'ipProtocol'  => String,
         'ipRanges'    => [Fog::Nullable::Hash],
+        'ipv6Ranges'  => [Fog::Nullable::Hash],
         'toPort'      => Fog::Nullable::Integer,
       }],
       'ipPermissionsEgress' => [],
@@ -54,16 +55,19 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>1,
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"tcp",
         "toPort"=>65535},
       {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>1,
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"udp",
         "toPort"=>65535},
       {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>-1,
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"icmp",
         "toPort"=>-1}
     ]
@@ -88,6 +92,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
         [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
           {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>1,
         "toPort"=>65535},
@@ -95,6 +100,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
         [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
           {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"udp",
         "fromPort"=>1,
         "toPort"=>65535},
@@ -102,6 +108,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
         [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
           {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"icmp",
         "fromPort"=>-1,
         "toPort"=>-1}
@@ -133,6 +140,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     expected_permissions += [
       {"groups"=>[],
         "ipRanges"=>[{"cidrIp"=>"10.0.0.0/8"}],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>22,
         "toPort"=>22}
@@ -164,7 +172,8 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       'IpPermissions' => [
         {
           'IpProtocol' => 'tcp', 'FromPort' => '80', 'ToPort' => '80',
-          'IpRanges' => [{ 'CidrIp' => '192.168.0.0/24' }]
+          'IpRanges' => [{ 'CidrIp' => '192.168.0.0/24' }],
+          'Ipv6Ranges' => []
         }
       ]
     }
@@ -177,6 +186,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     expected_permissions += [
       {"groups"=>[],
         "ipRanges"=>[{"cidrIp"=>"192.168.0.0/24"}],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>80,
         "toPort"=>80}
@@ -204,6 +214,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     expected_permissions += [
       {"groups"=>[{"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
+        "ipv6Ranges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>8000,
         "toPort"=>8000}


### PR DESCRIPTION
This change adds adding IPv6 security group rules.

The current security groups tests are pending, so I didn't add any new tests.
This fork does allow me to authorize and revoke IPv6 rules for ingress.
I could not test the egress implementation, as I'm currently not using it.