### PR TITLE
Add json files to the gem file

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fog/fog-aws"
   spec.license       = "MIT"
 
-  spec.files         = Dir['lib/**/*.rb', 'tests/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md',
-                           'CONTRIBUTORS.md', 'LICENSE.md', 'README.md', 'fog-aws.gemspec',]
+  spec.files         = Dir['lib/**/*.rb', 'lib/**/*.json', 'tests/**/*',
+                           'CHANGELOG.md', 'CONTRIBUTING.md', 'CONTRIBUTORS.md',
+                           'LICENSE.md', 'README.md', 'fog-aws.gemspec',]
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This will add following IAM related JSON files back into the gem file:
* lib/fog/aws/iam/default_policies.json
* lib/fog/aws/iam/default_policy_versions.json

These files appear to have been accidentally dropped as of v3.10.0.

---
I found this when running a test suite for an internal project, on a call to `Fog::AWS::IAM.get_server_certificate`, where it reported that `lib/fog/aws/iam/default_policies.rb` was missing.

Since, this is a problem with the contents of the gem, I do not think that there is a test to update.  I have also not opened a separate issue for this bug, because I think that this PR fixes the problem. But if you want a separate issue for tracking I am happy to open one.