### PR TITLE
Exclude test files from gem

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -14,11 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fog/fog-aws"
   spec.license       = "MIT"
 
-  spec.files         = Dir['lib/**/*.rb', 'lib/**/*.json', 'tests/**/*',
+  spec.files         = Dir['lib/**/*.{rb,json}',
                            'CHANGELOG.md', 'CONTRIBUTING.md', 'CONTRIBUTORS.md',
                            'LICENSE.md', 'README.md', 'fog-aws.gemspec',]
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
This gem contains test files totaling 1.4MB, which can be excluded from the package since they should not be needed at runtime.

```
$ du -sh *
80K	CHANGELOG.md
4.0K	CONTRIBUTING.md
8.0K	CONTRIBUTORS.md
4.0K	LICENSE.md
4.0K	README.md
4.0K	fog-aws.gemspec
6.1M	lib
1.4M	tests
```

According to https://github.com/rubygems/guides/issues/90, `spec.test_files` is no longer in use.