### PR TITLE
Drop ipaddress dependency in favor of built in ipaddr

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fog-core',  '~> 2.1'
   spec.add_dependency 'fog-json',  '~> 1.1'
   spec.add_dependency 'fog-xml',   '~> 0.1'
-  spec.add_dependency 'ipaddress', '~> 0.8'
 end

--- a/lib/fog/aws/requests/compute/create_subnet.rb
+++ b/lib/fog/aws/requests/compute/create_subnet.rb
@@ -2,7 +2,7 @@ module Fog
   module AWS
     class Compute
       class Real
-        require 'ipaddress'
+        require 'ipaddr'
         require 'fog/aws/parsers/compute/create_subnet'
 
         # Creates a Subnet with the CIDR block you specify.
@@ -50,11 +50,11 @@ module Fog
               if vpc.nil?
                 raise Fog::AWS::Compute::NotFound.new("The vpc ID '#{vpcId}' does not exist")
               end
-              if ! ::IPAddress.parse(vpc['cidrBlock']).include?(::IPAddress.parse(cidrBlock))
+              if ! ::IPAddr.new(vpc['cidrBlock']).include?(::IPAddr.new(cidrBlock))
                 raise Fog::AWS::Compute::Error.new("Range => The CIDR '#{cidrBlock}' is invalid.")
               end
               self.data[:subnets].select{ |s| s['vpcId'] == vpcId }.each do |subnet|
-                if ::IPAddress.parse(subnet['cidrBlock']).include?(::IPAddress.parse(cidrBlock))
+                if ::IPAddr.new(subnet['cidrBlock']).include?(::IPAddr.new(cidrBlock))
                   raise Fog::AWS::Compute::Error.new("Conflict => The CIDR '#{cidrBlock}' conflicts with another subnet")
                 end
               end


### PR DESCRIPTION
The ipaddr module is part of Ruby itself and can be used to check for range inclusion.

I don't have the capacity to test this properly and it doesn't appear to be covered by tests. Please review carefully.