### PR TITLE
change sync_clock to plain GET

### DIFF
--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -6,7 +6,7 @@ module Fog
         #
         def sync_clock
           response = begin
-            get_service
+            Excon.get("#{@scheme}://#{@host}")
           rescue Excon::Errors::HTTPStatusError => error
             error.response
           end


### PR DESCRIPTION
Perform an unauthenticated GET request to the root S3 URL to prevent 403 errors if the user doesn't have ListBuckets permissions