### PR TITLE
Replace URI.decode as obsolete, and removed in Ruby 3.0

### DIFF
--- a/lib/fog/aws/parsers/iam/get_group_policy.rb
+++ b/lib/fog/aws/parsers/iam/get_group_policy.rb
@@ -14,7 +14,7 @@ module Fog
             when 'GroupName', 'PolicyName'
               @response[name] = value
             when 'PolicyDocument'
-              @response['Policy'][name] = if decoded_string = URI.decode(value)
+              @response['Policy'][name] = if decoded_string = URI.decode_www_form_component(value)
                                   Fog::JSON.decode(decoded_string) rescue value
                                 else
                                   value

--- a/lib/fog/aws/parsers/iam/get_role_policy.rb
+++ b/lib/fog/aws/parsers/iam/get_role_policy.rb
@@ -12,7 +12,7 @@ module Fog
             when 'RoleName', 'PolicyName'
               @response['Policy'][name] = value
             when 'PolicyDocument'
-              @response['Policy'][name] = if decoded_string = URI.decode(value)
+              @response['Policy'][name] = if decoded_string = URI.decode_www_form_component(value)
                                   Fog::JSON.decode(decoded_string) rescue value
                                 else
                                   value

--- a/lib/fog/aws/parsers/iam/get_user_policy.rb
+++ b/lib/fog/aws/parsers/iam/get_user_policy.rb
@@ -14,7 +14,7 @@ module Fog
             when 'UserName', 'PolicyName'
               @response['Policy'][name] = value
             when 'PolicyDocument'
-              @response['Policy'][name] = if decoded_string = URI.decode(value)
+              @response['Policy'][name] = if decoded_string = URI.decode_www_form_component(value)
                                   Fog::JSON.decode(decoded_string) rescue value
                                 else
                                   value

--- a/lib/fog/aws/parsers/iam/policy_version.rb
+++ b/lib/fog/aws/parsers/iam/policy_version.rb
@@ -18,7 +18,7 @@ module Fog
             when 'IsDefaultVersion'
               @version[name] = (value == 'true')
             when 'Document'
-              @version[name] = if decoded_string = URI.decode(value)
+              @version[name] = if decoded_string = URI.decode_www_form_component(value)
                                  Fog::JSON.decode(decoded_string) rescue value
                                else
                                  value


### PR DESCRIPTION
Resolves https://github.com/fog/fog-aws/issues/653

Replace with URI.decode_www_form_component which has been available since Ruby 1.9

I'm not sure if there's any tests to add / update.

Based on https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/lint/uri_escape_unescape.rb, we have three options:

1. CGI.escape
2. URI.encode_www_form
3. URI.encode_www_form_component

2 is complicated because it returns an Array instead of a String. 3 seems a better fit than 1. Also:


```
irb(main):001:0> string = '?a=%09%0D'
=> "?a=%09%0D"
irb(main):002:0> URI.decode_www_form_component(string) == URI.decode(string)
(irb):2: warning: URI.unescape is obsolete
=> true

irb(main):004:0> require 'cgi'
=> true
irb(main):005:0> CGI.escape(string)
=> "%3Fa%3D%2509%250D"
irb(main):006:0> CGI.escape(string) == URI.decode(string)
(irb):6: warning: URI.unescape is obsolete
=> false
```

