### PR TITLE
Add missing AWS region "eu-south-2" - Europe (Spain)

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -230,7 +230,7 @@ module Fog
         'cn-northwest-1',
         'eu-central-1',
         'eu-north-1',
-        'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-south-1',
+        'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-south-1', 'eu-south-2',
         'me-south-1',
         'us-east-1', 'us-east-2',
         'us-west-1', 'us-west-2',


### PR DESCRIPTION
Add missing AWS region "eu-south-2" - Europe (Spain)
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html