### PR TITLE
Fix S3 Transfer Acceleration

### DIFF
--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -6,11 +6,19 @@ module Fog
         #
         def sync_clock
           response = begin
-            Excon.get("#{@scheme}://#{@host}")
+            Excon.get(sync_clock_url)
           rescue Excon::Errors::HTTPStatusError => error
             error.response
           end
           Fog::Time.now = Time.parse(response.headers['Date'])
+        end
+
+        private
+
+        def sync_clock_url
+          host = @acceleration ? region_to_host(@region) : @host
+
+          "#{@scheme}://#{host}"
         end
       end # Real
 


### PR DESCRIPTION
We use S3 Transfer Acceleration which was added in https://github.com/fog/fog-aws/pull/505.

In 3.15.0 it [was broken](https://github.com/fog/fog-aws/pull/651):

```
vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/socket.rb:170:in `connect': no address for s3-accelerate.amazonaws.com (Resolv::ResolvError) (Excon::Error::Socket)
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/ssl_socket.rb:193:in `connect'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/socket.rb:51:in `initialize'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/ssl_socket.rb:10:in `initialize'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/connection.rb:474:in `new'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/connection.rb:474:in `socket'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/connection.rb:121:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/middlewares/mock.rb:57:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/middlewares/instrumentor.rb:34:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/middlewares/idempotent.rb:19:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/middlewares/base.rb:22:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/middlewares/base.rb:22:in `request_call'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon/connection.rb:286:in `request'
    from vendor/bundle/ruby/3.1.0/gems/excon-0.99.0/lib/excon.rb:260:in `get'
    from vendor/bundle/ruby/3.1.0/gems/fog-aws-3.18.0/lib/fog/aws/requests/storage/sync_clock.rb:9:in `sync_clock'
```

I think for S3 Transfer Acceleration we can use default host as it was before.