### PR TITLE
gopalcoupa:add-me-central-1

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -231,7 +231,7 @@ module Fog
         'eu-central-1',
         'eu-north-1',
         'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-south-1', 'eu-south-2',
-        'me-south-1',
+        'me-south-1','me-central-1',
         'us-east-1', 'us-east-2',
         'us-west-1', 'us-west-2',
         'sa-east-1',


### PR DESCRIPTION
Add missing AWS region: me-central-1 (Middle East (UAE))

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html