### PR TITLE
Change method sync_clock_url to use localstack set a different port

### DIFF
--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -18,7 +18,7 @@ module Fog
         def sync_clock_url
           host = @acceleration ? region_to_host(@region) : @host
 
-          "#{@scheme}://#{host}"
+          "#{@scheme}://#{host}:#{@port}"
         end
       end # Real
 


### PR DESCRIPTION
Correct the sync_clock_url method so that it is possible to connect to a port other than the default one.
Use case where it needs to be a different port than the default one, is using localstack s3 in a development environment.