### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head', 'truffleruby-head']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'head', 'truffleruby-head']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR just adds Ruby 3.2 to the test matrix.