### PR TITLE
Prevent `Unrecognized arguments: sts_endpoint` warning

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -8,7 +8,7 @@ module Fog
       class ValidationError < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/auto_scaling'
       request :attach_load_balancers

--- a/lib/fog/aws/beanstalk.rb
+++ b/lib/fog/aws/beanstalk.rb
@@ -6,7 +6,7 @@ module Fog
       class InvalidParameterError < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/beanstalk'
 

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :version, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :version, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :region, :sts_endpoint
 
       model_path 'fog/aws/models/cdn'
       model       :distribution

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/cloud_formation'
       request :cancel_update_stack

--- a/lib/fog/aws/cloud_watch.rb
+++ b/lib/fog/aws/cloud_watch.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/cloud_watch'
 

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -6,7 +6,7 @@ module Fog
       class RequestLimitExceeded < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :version, :retry_request_limit_exceeded, :retry_jitter_magnitude
+      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :version, :retry_request_limit_exceeded, :retry_jitter_magnitude, :sts_endpoint
 
       secrets    :aws_secret_access_key, :hmac, :aws_session_token
 

--- a/lib/fog/aws/data_pipeline.rb
+++ b/lib/fog/aws/data_pipeline.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/data_pipeline'
       request :activate_pipeline

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :version, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :version, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :region, :sts_endpoint
 
       model_path 'fog/aws/models/dns'
       model       :record

--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :aws_session_token, :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :aws_session_token, :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/dynamodb'
       request :batch_get_item

--- a/lib/fog/aws/ecs.rb
+++ b/lib/fog/aws/ecs.rb
@@ -3,7 +3,7 @@ module Fog
     class ECS < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name,:sts_endpoint
 
       request_path 'fog/aws/requests/ecs'
       request :list_clusters

--- a/lib/fog/aws/elasticache.rb
+++ b/lib/fog/aws/elasticache.rb
@@ -8,7 +8,7 @@ module Fog
       class AuthorizationAlreadyExists < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/elasticache'
 

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -14,7 +14,7 @@ module Fog
       class ValidationError             < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name,:sts_endpoint
 
       request_path 'fog/aws/requests/elb'
       request :configure_health_check

--- a/lib/fog/aws/elbv2.rb
+++ b/lib/fog/aws/elbv2.rb
@@ -2,7 +2,7 @@ module Fog
   module AWS
     class ELBV2 < ELB
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name,:sts_endpoint
 
       request_path 'fog/aws/requests/elbv2'
       request :add_tags

--- a/lib/fog/aws/emr.rb
+++ b/lib/fog/aws/emr.rb
@@ -6,7 +6,7 @@ module Fog
       class IdentifierTaken < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/emr'
 

--- a/lib/fog/aws/glacier.rb
+++ b/lib/fog/aws/glacier.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/glacier'
 

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -10,7 +10,7 @@ module Fog
       class ValidationError < Fog::AWS::IAM::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent, :instrumentor, :instrumentor_name, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :region
+      recognizes :host, :path, :port, :scheme, :persistent, :instrumentor, :instrumentor_name, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :region, :sts_endpoint
 
       request_path 'fog/aws/requests/iam'
       request :add_user_to_group

--- a/lib/fog/aws/kinesis.rb
+++ b/lib/fog/aws/kinesis.rb
@@ -12,7 +12,7 @@ module Fog
       class ProvisionedThroughputExceeded < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/kinesis'
 

--- a/lib/fog/aws/kms.rb
+++ b/lib/fog/aws/kms.rb
@@ -14,7 +14,7 @@ module Fog
       NotFoundException                = Class.new(Fog::Errors::Error)
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :instrumentor, :instrumentor_name, :aws_credentials_expire_at, :sts_endpoint
 
       request_path 'fog/aws/requests/kms'
       request :list_keys

--- a/lib/fog/aws/lambda.rb
+++ b/lib/fog/aws/lambda.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/lambda'
       request :create_function

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -9,7 +9,7 @@ module Fog
       class AuthorizationAlreadyExists < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :version, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/rds'
       request :describe_events

--- a/lib/fog/aws/redshift.rb
+++ b/lib/fog/aws/redshift.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/redshift'
 

--- a/lib/fog/aws/ses.rb
+++ b/lib/fog/aws/ses.rb
@@ -7,7 +7,7 @@ module Fog
       class MessageRejected < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/ses'
       request :delete_verified_email_address

--- a/lib/fog/aws/simpledb.rb
+++ b/lib/fog/aws/simpledb.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :nil_string, :path, :port, :scheme, :persistent, :region, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :nil_string, :path, :port, :scheme, :persistent, :region, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/simpledb'
       request :batch_put_attributes

--- a/lib/fog/aws/sns.rb
+++ b/lib/fog/aws/sns.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :host, :path, :port, :scheme, :persistent, :region, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/sns'
       request :add_permission

--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :sts_endpoint
 
       request_path 'fog/aws/requests/sqs'
       request :change_message_visibility

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -46,7 +46,7 @@ module Fog
       ]
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version, :enable_signature_v4_streaming, :virtual_host, :cname, :max_put_chunk_size, :max_copy_chunk_size, :aws_credentials_refresh_threshold_seconds, :disable_content_md5_validation
+      recognizes :endpoint, :region, :host, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style, :acceleration, :instrumentor, :instrumentor_name, :aws_signature_version, :enable_signature_v4_streaming, :virtual_host, :cname, :max_put_chunk_size, :max_copy_chunk_size, :aws_credentials_refresh_threshold_seconds, :disable_content_md5_validation, :sts_endpoint
 
       secrets    :aws_secret_access_key, :hmac
 

--- a/lib/fog/aws/support.rb
+++ b/lib/fog/aws/support.rb
@@ -4,7 +4,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :instrumentor, :instrumentor_name, :region, :persistent, :aws_session_token
+      recognizes :host, :path, :port, :scheme, :instrumentor, :instrumentor_name, :region, :persistent, :aws_session_token, :aws_credentials_expire_at, :sts_endpoint
 
       model_path 'fog/aws/models/support'
       request_path 'fog/aws/requests/support'

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Shindo.tests('AWS | credentials', ['aws']) do
-  unchecked_constants = [:CredentialFetcher, :VERSION, :Errors, :Mock, :ServiceMapper, :Federation, :STS, :SignatureV4, :EFS]
+  unchecked_constants = [:CredentialFetcher, :VERSION, :Errors, :Mock, :ServiceMapper, :Federation, :STS, :SignatureV4, :EFS, :Parsers]
 
   test_services = Fog::AWS.constants.delete_if { |service| unchecked_constants.include?(service) }
 

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -6,7 +6,7 @@ Shindo.tests('AWS | credentials', ['aws']) do
   test_services = Fog::AWS.constants.delete_if { |service| unchecked_constants.include?(service) }
 
   target_services = test_services.each_with_object([]) do |name, services|
-    services << Class.const_get("Fog::AWS::#{name}")
+    services << Object.const_get("Fog::AWS::#{name}")
   end
   require_credential_parameters = [:aws_access_key_id, :aws_secret_access_key]
   recognized_credential_parameters = [:aws_session_token, :aws_credentials_expire_at, :region, :sts_endpoint]


### PR DESCRIPTION
This is a solution for https://github.com/fog/fog-aws/issues/683

## Description

I try to fix three points in this PR.

1. Fix `[fog][WARNING] Unrecognized arguments: sts_endpoint` warring
   - this is the main topic since #683

2. Add another related parameter such as a `region`
   - In coding, I found the `Unrecognized arguments:` warning is not only `sts_endpoint`. So I try to fix other parameters' warnings.

3. Add tests that prevent those warnings from automatically
   - Currently, we need to manually cross-check how to correct parameters that are set on each AWS Service class when the corresponding AWS new services or add extra parameters to CredentialFetcher.
   - So I try to do that operation in the test. 
