### PR TITLE
Fog::AWS::Storage::File - fix request id header reflection

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -180,7 +180,8 @@ module Fog
 
         remove_method :metadata
         def metadata
-          attributes.reject {|key, value| !(key.to_s =~ /^x-amz-/)}
+          attributes.reject {|key, value| !(key.to_s =~ /^x-amz-/) }
+                    .reject {|key, value| ['x-amz-id-2', 'x-amz-request-id'].include?(key) }
         end
 
         remove_method :metadata=

--- a/tests/models/storage/file_tests.rb
+++ b/tests/models/storage/file_tests.rb
@@ -24,6 +24,23 @@ Shindo.tests("Storage[:aws] | file", ["aws"]) do
 
   end
 
+  model_tests(@directory.files, file_attributes, Fog.mocking?) do
+    @instance.attributes.merge!(
+      'x-amz-id-2' => 'eTTGXYpQIoD8+5fB8vdYO8s056GyoCsb92KD7rkRXzUoDb8Sb/BU0yhc2vbwP3raHEHWoY53LX8=',
+      'x-amz-request-id' => '7DC5XMTZZ1W1HVVB'
+    )
+
+    tests("#metadata") do
+      tests("#metadata excludes x-amz-id-2").returns(nil) do
+        @instance.metadata['x-amz-id-2']
+      end
+
+      tests("#metadata excludes x-amz-request-id").returns(nil) do
+        @instance.metadata['x-amz-request-id']
+      end
+    end
+  end
+
   @directory.versioning = true
 
   model_tests(@directory.files, file_attributes, Fog.mocking?) do
@@ -74,7 +91,7 @@ Shindo.tests("Storage[:aws] | file", ["aws"]) do
       pending if Fog.mocking?
 
       @empty_file = Tempfile.new("fog-test-aws-s3-multipart-empty")
-     
+
       tests("#save(:multipart_chunk_size => 5242880)").succeeds do
         @directory.files.create(:key => 'empty-multipart-upload', :body => @empty_file, :multipart_chunk_size => 5242880)
       end


### PR DESCRIPTION
Resolves #688

---

This fixed behaviour in the following scenario:

```ruby
s3 = Fog::Storage.new(config)
bucket = s3.directories.new(key: 'rahim-throwaway-us-east-1')
file = bucket.files.create(key: 'foo', body: 'bar')
file = bucket.files.get('foo')
# =>   <Fog::AWS::Storage::File
#     key="foo",
#     cache_control=nil,
#     content_disposition=nil,
#     content_encoding=nil,
#     content_length=3,
#     content_md5=nil,
#     content_type="",
#     etag="37b51d194a7513e45b56f6524f2d51f2",
#     expires=nil,
#     last_modified=2023-09-19 15:18:30 +0000,
#     metadata={"x-amz-id-2"=>"P6b145GU6tllNufELCAYtGGNIvqijkuVoayaabSTGi3d4dVxzZCM5TYiaCgZhvOpmJO/SKTHyOnpQw65oXKXug==", "x-amz-request-id"=>"PAYX90KF2VFZMBVH"},
#     owner=nil,
#     storage_class=nil,
#     encryption="AES256",
#     encryption_key=nil,
#     version=nil,
#     kms_key_id=nil,
#     tags=nil,
#     website_redirect_location=nil
#   >
file.save
# The file instance above carries state from previous API requests.
# In particular fog carries forward x-amz-id-2 and x-amz-request-id from
# the last response and includes that in the next request
#
# Most of the time S3 just ignores this silently, but intermittently it
# becomes more fussy and rejects with Forbidden
```