### PR TITLE
Fog::AWS::Storage don't retry client errors

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -554,7 +554,8 @@ module Fog
           @use_iam_profile = options[:use_iam_profile]
           @instrumentor       = options[:instrumentor]
           @instrumentor_name  = options[:instrumentor_name] || 'fog.aws.storage'
-          @connection_options = options[:connection_options] || DEFAULT_CONNECTION_OPTIONS
+          @connection_options =
+            DEFAULT_CONNECTION_OPTIONS.merge(options[:connection_options] || {})
           @persistent = options.fetch(:persistent, false)
           @acceleration = options.fetch(:acceleration, false)
           @signature_version = options.fetch(:aws_signature_version, 4)

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -14,6 +14,14 @@ module Fog
         'https' => 443
       }
 
+      DEFAULT_CONNECTION_OPTIONS = {
+        retry_limit: 5,
+        retry_interval: 1,
+        retry_errors: [
+          Excon::Error::Timeout, Excon::Error::Socket, Excon::Error::Server
+        ]
+      }
+
       MIN_MULTIPART_CHUNK_SIZE = 5242880
       MAX_SINGLE_PUT_SIZE = 5368709120
 
@@ -546,7 +554,7 @@ module Fog
           @use_iam_profile = options[:use_iam_profile]
           @instrumentor       = options[:instrumentor]
           @instrumentor_name  = options[:instrumentor_name] || 'fog.aws.storage'
-          @connection_options     = options[:connection_options] || { retry_limit: 5, retry_interval: 1 }
+          @connection_options = options[:connection_options] || DEFAULT_CONNECTION_OPTIONS
           @persistent = options.fetch(:persistent, false)
           @acceleration = options.fetch(:acceleration, false)
           @signature_version = options.fetch(:aws_signature_version, 4)


### PR DESCRIPTION
Resolves #690

Excon's default configuration retries HTTP 4xx class errors, which we generally can't expect to be resolved by retry. Combined with relatively recent retry config added in https://github.com/fog/fog-aws/issues/674 we were seeing S3 calls to non-existent objects take multiple seconds when made via fog-aws.

See the issue for detailed explanation of the underlying cause.

Though this resolves the problem, I question whether it's the right approach:
- it's odd that the default retry behaviour (and connection options) for `Fog::AWS::Storage` are different to all the other services covered by fog-aws.
- ~~we create something of a foot gun, because someone who chooses to just configure eg `retry_limit` (or any other arbitrary connection option) will inadvertently set `retry_errors` back to Excon's default.~~ (addressed in later commit)
- possibly this is better addressed in Excon, I've opend https://github.com/excon/excon/issues/833 to ask that question there