### PR TITLE
Add ca-west-1 region

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -225,7 +225,7 @@ module Fog
         'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
         'ap-south-1',
         'ap-southeast-1', 'ap-southeast-2', 'ap-southeast-3', 'ap-southeast-4',
-        'ca-central-1',
+        'ca-central-1', 'ca-west-1',
         'cn-north-1',
         'cn-northwest-1',
         'eu-central-1',


### PR DESCRIPTION
Add ca-west-1 region to region list in aws.rb
This is an attempt to fix the missing region (based on comments in #701 ), my live testing suggests it works, but I am inexperienced with ruby programming.

 fixes #701 
