### PR TITLE
Fix frozen string literal issue for ruby 3.4.0

### DIFF
--- a/lib/fog/aws/signaturev4.rb
+++ b/lib/fog/aws/signaturev4.rb
@@ -106,7 +106,7 @@ DATA
       end
 
       def canonical_headers(headers)
-        canonical_headers = ''
+        canonical_headers = +''
 
         for key in headers.keys.sort_by {|k| k.to_s.downcase}
           canonical_headers << "#{key.to_s.downcase}:#{headers[key].to_s.strip}\n"


### PR DESCRIPTION
To prepare for ruby 3.4.0 and making strings frozen by default, I've stumbled upon this string mutation.

Let me know if you need anything ( I didn't add tests since I assume tests exist for this feature )