### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/fog-aws

### DIFF
--- a/fog-aws.gemspec
+++ b/fog-aws.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fog-core',  '~> 2.1'
   spec.add_dependency 'fog-json',  '~> 1.1'
   spec.add_dependency 'fog-xml',   '~> 0.1'
+
+  spec.metadata['changelog_uri'] = spec.homepage + '/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/fog-aws which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/