### PR TITLE
Prefer AWS_REGION over AWS_DEFAULT_REGION in credential fetching

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -21,7 +21,7 @@ module Fog
           if options[:use_iam_profile]
             begin
               role_data = nil
-              region = options[:region] || ENV["AWS_DEFAULT_REGION"]
+              region = options[:region] || ENV["AWS_REGION"] || ENV["AWS_DEFAULT_REGION"]
 
               if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
                 connection = options[:connection] || Excon.new(CONTAINER_CREDENTIALS_HOST)

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -151,8 +151,23 @@ Shindo.tests('AWS | credentials', ['aws']) do
     end
 
     ENV["AWS_DEFAULT_REGION"] = "us-west-1"
+    ENV["AWS_REGION"] = nil
 
-    tests('#fetch_credentials with regional STS endpoint with region in env') do
+    tests('#fetch_credentials with regional STS endpoint with AWS_DEFAULT_REGION in env') do
+      returns(
+        aws_access_key_id: 'dummykey',
+        aws_secret_access_key: 'dummysecret',
+        aws_session_token: 'dummytoken',
+        region: 'us-west-1',
+        sts_endpoint: "https://sts.us-west-1.amazonaws.com",
+        aws_credentials_expire_at: expires_at
+      ) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
+    end
+
+    ENV["AWS_DEFAULT_REGION"] = "us-west-2"
+    ENV["AWS_REGION"] = "us-west-1"
+
+    tests('#fetch_credentials with regional STS endpoint with AWS_REGION in env') do
       returns(
         aws_access_key_id: 'dummykey',
         aws_secret_access_key: 'dummysecret',
@@ -165,6 +180,7 @@ Shindo.tests('AWS | credentials', ['aws']) do
 
     ENV["AWS_STS_REGIONAL_ENDPOINTS"] = nil
     ENV["AWS_DEFAULT_REGION"] = nil
+    ENV["AWS_REGION"] = nil
     ENV['AWS_WEB_IDENTITY_TOKEN_FILE'] = nil
 
     storage = Fog::Storage.new(


### PR DESCRIPTION
As https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html#feature-region-sdk-compat describes, the AWS CLI v2 uses AWS_REGION before AWS_DEFAULT_VERSION.