### PR TITLE
Drop warning if region is not us-east-1 in mock

### DIFF
--- a/lib/fog/aws/requests/storage/put_bucket.rb
+++ b/lib/fog/aws/requests/storage/put_bucket.rb
@@ -61,10 +61,6 @@ DATA
           end
           if !self.data[:buckets][bucket_name]
             self.data[:buckets][bucket_name] = bucket
-          elsif self.region != 'us-east-1'
-            response.status = 409
-            Fog::Logger.warning "Your region '#{self.region}' does not match the default region 'us-east-1'"
-            raise(Excon::Errors.status_error({:expects => 201}, response))
           end
           response
         end

--- a/tests/requests/storage/bucket_tests.rb
+++ b/tests/requests/storage/bucket_tests.rb
@@ -395,16 +395,6 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       Fog::Storage[:aws].put_bucket_website('fognonbucket', 'index.html')
     end
 
-    tests('put existing bucket - non-default region') do
-      storage_eu_endpoint = Fog::Storage[:aws]
-      storage_eu_endpoint.region = "eu-west-1"
-      storage_eu_endpoint.put_bucket(@aws_bucket_name)
-
-      tests("#put_bucket('#{@aws_bucket_name}') existing").raises(Excon::Errors::Conflict) do
-        storage_eu_endpoint.put_bucket(@aws_bucket_name)
-      end
-    end
-
     tests("#put_bucket_website('fognonbucket', :RedirectAllRequestsTo => 'redirect.example.com')").raises(Excon::Errors::NotFound) do
       Fog::Storage[:aws].put_bucket_website('fognonbucket', :RedirectAllRequestsTo => 'redirect.example.com')
     end


### PR DESCRIPTION
Previously if `Fog.mock!` were used with some other region and the bucket already existed, a warning message, `Your region <region> does not match the default region 'us-east-1'`.

We were seeing a lot of these warnings in our test suite. As far as I can tell, there's no reason why some other region can't be used, so drop this.