### PR TITLE
Disable S3 Signature v4 Streaming by default

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -559,7 +559,7 @@ module Fog
           @persistent = options.fetch(:persistent, false)
           @acceleration = options.fetch(:acceleration, false)
           @signature_version = options.fetch(:aws_signature_version, 4)
-          @enable_signature_v4_streaming = options.fetch(:enable_signature_v4_streaming, true)
+          @enable_signature_v4_streaming = options.fetch(:enable_signature_v4_streaming, false)
           validate_signature_version!
           @path_style = options[:path_style]  || false
 


### PR DESCRIPTION
The STREAMING-AWS4-HMAC-SHA256-PAYLOAD streaming method is not widely implemented in AWS SDKs, and many third-party S3 implementations don't support this.

S3 multipart uploads are a more standard way of handling chunked transfers in any case.