### PR TITLE
Support AWS_ENDPOINT_URL_STS environment variable

### DIFF
--- a/lib/fog/aws/credential_fetcher.rb
+++ b/lib/fog/aws/credential_fetcher.rb
@@ -56,7 +56,9 @@ module Fog
                 }
 
                 sts_endpoint =
-                  if ENV["AWS_STS_REGIONAL_ENDPOINTS"] == "regional" && region
+                  if ENV["AWS_ENDPOINT_URL_STS"]
+                    ENV["AWS_ENDPOINT_URL_STS"]
+                  elsif ENV["AWS_STS_REGIONAL_ENDPOINTS"] == "regional" && region
                     "https://sts.#{region}.amazonaws.com"
                   else
                     "https://sts.amazonaws.com"

--- a/tests/credentials_tests.rb
+++ b/tests/credentials_tests.rb
@@ -202,6 +202,20 @@ Shindo.tests('AWS | credentials', ['aws']) do
       ) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
     end
 
+    ENV["AWS_ENDPOINT_URL_STS"] = "https://my-special-sts.amazonaws.com"
+
+    tests('#fetch_credentials with global STS endpoint set in env') do
+      returns(
+        aws_access_key_id: 'dummykey',
+        aws_secret_access_key: 'dummysecret',
+        aws_session_token: 'dummytoken',
+        region: 'us-west-1',
+        sts_endpoint: "https://my-special-sts.amazonaws.com",
+        aws_credentials_expire_at: expires_at
+      ) { Fog::AWS::Compute.fetch_credentials(use_iam_profile: true) }
+    end
+
+    ENV["AWS_ENDPOINT_URL_STS"] = nil
     ENV["AWS_STS_REGIONAL_ENDPOINTS"] = nil
     ENV["AWS_DEFAULT_REGION"] = nil
     ENV["AWS_REGION"] = nil


### PR DESCRIPTION
As described in https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html, the STS endpoint can be configured with the AWS_ENDPOINT_URL_STS environment variable. This might be necessary for users of Amazon Secret Cloud (https://aws.amazon.com/federal/secret-cloud/), for example.