### PR TITLE
Support FIPS endpoints, disable S3 Transfer Acceleration in GovCloud

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -7,6 +7,8 @@ module Fog
 
       DEFAULT_REGION = 'us-east-1'
       ACCELERATION_HOST = 's3-accelerate.amazonaws.com'
+      AWS_FIPS_REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'us-gov-east-1', 'us-gov-west-1', 'ca-central-1', 'ca-west-1'].freeze
+      AWS_GOVCLOUD_REGIONS = ['us-gov-east-1', 'us-gov-west-1'].freeze
 
       DEFAULT_SCHEME = 'https'
       DEFAULT_SCHEME_PORT = {
@@ -258,13 +260,17 @@ module Fog
         end
 
         def region_to_host(region=nil)
-          case region.to_s
-          when DEFAULT_REGION, ''
-            's3.amazonaws.com'
-          when %r{\Acn-.*}
-            "s3.#{region}.amazonaws.com.cn"
+          if ENV['AWS_USE_FIPS_ENDPOINT'] == 'true' && region in AWS_FIPS_REGIONS
+            "s3-fips.#{region}.amazonaws.com"  # https://aws.amazon.com/compliance/fips/
           else
-            "s3.#{region}.amazonaws.com"
+            case region.to_s
+            when DEFAULT_REGION, ''
+              's3.amazonaws.com'
+            when %r{\Acn-.*}
+              "s3.#{region}.amazonaws.com.cn"
+            else
+              "s3.#{region}.amazonaws.com"
+            end
           end
         end
 
@@ -578,7 +584,9 @@ module Fog
             @port       = options[:port]        || DEFAULT_SCHEME_PORT[@scheme]
           end
 
-          @host = ACCELERATION_HOST if @acceleration
+          # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
+          # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
+          @host = ACCELERATION_HOST if @acceleration && (not @region in AWS_GOVCLOUD_REGIONS) && ENV['AWS_USE_FIPS_ENDPOINT'] != 'true'
           setup_credentials(options)
         end
 

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -586,7 +586,12 @@ module Fog
 
           # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
           # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
-          @host = ACCELERATION_HOST if @acceleration && !AWS_GOVCLOUD_REGIONS.include?(@region) && ENV['AWS_USE_FIPS_ENDPOINT'] != 'true'
+          if @acceleration && (AWS_GOVCLOUD_REGIONS.include?(@region) || ENV['AWS_USE_FIPS_ENDPOINT'] == 'true')
+            Fog::Logger.warning("fog: S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling accelearation.")
+            @acceleration = false
+          end
+
+          @host = ACCELERATION_HOST if @acceleration
           setup_credentials(options)
         end
 

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -7,8 +7,8 @@ module Fog
 
       DEFAULT_REGION = 'us-east-1'
       ACCELERATION_HOST = 's3-accelerate.amazonaws.com'
-      AWS_FIPS_REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'us-gov-east-1', 'us-gov-west-1', 'ca-central-1', 'ca-west-1'].freeze
-      AWS_GOVCLOUD_REGIONS = ['us-gov-east-1', 'us-gov-west-1'].freeze
+      AWS_FIPS_REGIONS = %w(us-east-1 us-east-2 us-west-1 us-west-2 us-gov-east-1 us-gov-west-1 ca-central-1 ca-west-1).freeze
+      AWS_GOVCLOUD_REGIONS = %w(us-gov-east-1 us-gov-west-1).freeze
 
       DEFAULT_SCHEME = 'https'
       DEFAULT_SCHEME_PORT = {
@@ -260,8 +260,8 @@ module Fog
         end
 
         def region_to_host(region=nil)
-          if ENV['AWS_USE_FIPS_ENDPOINT'] == 'true' && region in AWS_FIPS_REGIONS
-            "s3-fips.#{region}.amazonaws.com"  # https://aws.amazon.com/compliance/fips/
+          if ENV['AWS_USE_FIPS_ENDPOINT'] == 'true' && AWS_FIPS_REGIONS.include?(region)
+            "s3-fips.#{region}.amazonaws.com" # https://aws.amazon.com/compliance/fips/
           else
             case region.to_s
             when DEFAULT_REGION, ''
@@ -586,7 +586,7 @@ module Fog
 
           # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
           # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
-          @host = ACCELERATION_HOST if @acceleration && (not @region in AWS_GOVCLOUD_REGIONS) && ENV['AWS_USE_FIPS_ENDPOINT'] != 'true'
+          @host = ACCELERATION_HOST if @acceleration && !AWS_GOVCLOUD_REGIONS.include?(@region) && ENV['AWS_USE_FIPS_ENDPOINT'] != 'true'
           setup_credentials(options)
         end
 

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -587,7 +587,7 @@ module Fog
           # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
           # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
           if @acceleration && (AWS_GOVCLOUD_REGIONS.include?(@region) || ENV['AWS_USE_FIPS_ENDPOINT'] == 'true')
-            Fog::Logger.warning("fog: S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling accelearation.")
+            Fog::Logger.warning("fog: S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling acceleration.")
             @acceleration = false
           end
 


### PR DESCRIPTION
The Fog::AWS::Utils region_to_host method returns the standard S3 endpoints even when ENV['AWS_USE_FIPS_ENDPOINT']=='true'.  When FIPS is called for, and we are in a region where FIPS endpoints are available,  this method should return the FIPS endpoint.

Furthermore, when S3 Transfer Acceleration (S3TA) is requested by configuration, the above endpoint gets overridden to select the S3TA endpoint.  However, S3TA is not avaialble in GovCloud, and has no FIPS endpoint equivalents.  In this instance, if the region is a GovCloud region, or if FIPS mode is called for, do _not_ override the endpoint to use S3TA.