### PR TITLE
Fix Compute.describe_instance_status parser

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_instance_status.rb
+++ b/lib/fog/aws/parsers/compute/describe_instance_status.rb
@@ -4,7 +4,7 @@ module Fog
       module Compute
         class DescribeInstanceStatus < Fog::Parsers::Base
           def new_instance!
-            @instance = { 'instanceState' => {}, 'systemStatus' => { 'details' => [] }, 'instanceStatus' => { 'details' => [] }, 'attachedEbsStatus' => { 'details' => [] },'eventsSet' => [] }
+            @instance = { 'instanceState' => {}, 'systemStatus' => { 'details' => [] }, 'instanceStatus' => { 'details' => [] }, 'attachedEbsStatus' => { 'details' => [] }, 'eventsSet' => [] }
           end
 
           def new_item!

--- a/lib/fog/aws/parsers/compute/describe_instance_status.rb
+++ b/lib/fog/aws/parsers/compute/describe_instance_status.rb
@@ -4,7 +4,7 @@ module Fog
       module Compute
         class DescribeInstanceStatus < Fog::Parsers::Base
           def new_instance!
-            @instance = { 'instanceState' => {}, 'systemStatus' => { 'details' => [] }, 'instanceStatus' => { 'details' => [] }, 'eventsSet' => [] }
+            @instance = { 'instanceState' => {}, 'systemStatus' => { 'details' => [] }, 'instanceStatus' => { 'details' => [] }, 'attachedEbsStatus' => { 'details' => [] },'eventsSet' => [] }
           end
 
           def new_item!
@@ -31,6 +31,8 @@ module Fog
               @inside = :instanceState
             when 'instanceStatus'
               @inside = :instanceStatus
+            when 'attachedEbsStatus'
+              @inside = :attachedEbsStatus
             when 'eventsSet'
               @inside = :eventsSet
             end
@@ -43,13 +45,13 @@ module Fog
               @instance[name] = value
             when 'nextToken', 'requestId'
               @response[name] = value
-            when 'systemStatus', 'instanceState', 'instanceStatus', 'eventsSet'
+            when 'systemStatus', 'instanceState', 'instanceStatus', 'attachedEbsStatus', 'eventsSet'
               @inside = nil
             when 'item'
               case @inside
               when :eventsSet
                 @instance['eventsSet'] << @item
-              when :systemStatus, :instanceStatus
+              when :systemStatus, :instanceStatus, :attachedEbsStatus
                 @instance[@inside.to_s]['details'] << @item
               when nil
                 @response['instanceStatusSet'] << @instance


### PR DESCRIPTION
Resolves https://github.com/fog/fog-aws/issues/734

## Test script
### Gemfile
```
source 'https://rubygems.org'

gem 'fog-aws', git: 'https://github.com/fog/fog-aws.git'
```

### describe_instance_status.rb
```
require 'fog/aws'

# Replace this with a real EC2 instance ID
INSTANCE_ID = 'i-*****' # provide instance ID

# Create a connection to EC2 using fog
compute = Fog::AWS::Compute.new(
  aws_access_key_id:     '***', # provide access key ID
  aws_secret_access_key: '***', # provide secret
  region:                'us-east-1' # Change region if needed
)

begin
  response = compute.describe_instance_status('InstanceId' => [INSTANCE_ID])
  statuses = response.body['instanceStatusSet']

  if statuses.empty?
    puts "No status found for instance #{INSTANCE_ID}"
  else
    status = statuses.first
    puts "Instance #{INSTANCE_ID} status:"
    puts "  Instance State: #{status['instanceState']['name']}"
    puts "  System Status:  #{status['systemStatus']['status']}"
    puts "  Instance Status: #{status['instanceStatus']['status']}"
  end
rescue => e
  puts "Error describing instance status: #{e.message}"
end
```

## Verification
### Before the fix
<img width="708" alt="Screenshot 2025-04-18 at 12 55 50" src="https://github.com/user-attachments/assets/c0656f0e-94bf-4849-b147-f5f524aba657" />

### After the fix
<img width="411" alt="Screenshot 2025-04-18 at 12 55 10" src="https://github.com/user-attachments/assets/44339425-4ef6-4266-b74c-5d9d688f0506" />
