### PR TITLE
bug(aws/storage): include non-standard port in Host header for signature v4

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -658,8 +658,9 @@ module Fog
           params = request_params(params)
           scheme = params.delete(:scheme)
           host   = params.delete(:host)
-          port   = params.delete(:port) || DEFAULT_SCHEME_PORT[scheme]
-          params[:headers]['Host'] = host
+          port   = params.delete(:port)
+          params[:headers]['Host'] = port ? "#{host}:#{port}" : host
+          port ||= DEFAULT_SCHEME_PORT[scheme]
 
 
           if @signature_version == 4

--- a/tests/storage_tests.rb
+++ b/tests/storage_tests.rb
@@ -5,3 +5,53 @@ Shindo.tests('AWS Storage | escape', ['aws']) do
     returns(Fog::AWS::Storage.new.send(:escape, 'key/with/prefix')) { 'key/with/prefix' }
   end
 end
+
+Shindo.tests('AWS Storage | Host header', ['aws']) do
+  def capture_host_header(storage)
+    captured_host = nil
+    storage.define_singleton_method(:_request) do |scheme, host, port, params, original_params, &block|
+      captured_host = params[:headers]['Host']
+      response = Excon::Response.new
+      response.status = 200
+      response
+    end
+    storage.put_object('testbucket', 'testkey', 'testbody')
+    captured_host
+  end
+
+  tests('includes port in Host header for non-standard port') do
+    storage = Fog::AWS::Storage::Real.new(
+      :aws_access_key_id    => 'test_key',
+      :aws_secret_access_key => 'test_secret',
+      :host                 => 'storage.example.com',
+      :port                 => 9000,
+      :scheme               => 'http',
+      :path_style           => true
+    )
+    returns('storage.example.com:9000') { capture_host_header(storage) }
+  end
+
+  tests('omits port in Host header for standard HTTP port') do
+    storage = Fog::AWS::Storage::Real.new(
+      :aws_access_key_id    => 'test_key',
+      :aws_secret_access_key => 'test_secret',
+      :host                 => 'storage.example.com',
+      :port                 => 80,
+      :scheme               => 'http',
+      :path_style           => true
+    )
+    returns('storage.example.com') { capture_host_header(storage) }
+  end
+
+  tests('omits port in Host header for standard HTTPS port') do
+    storage = Fog::AWS::Storage::Real.new(
+      :aws_access_key_id    => 'test_key',
+      :aws_secret_access_key => 'test_secret',
+      :host                 => 'storage.example.com',
+      :port                 => 443,
+      :scheme               => 'https',
+      :path_style           => true
+    )
+    returns('storage.example.com') { capture_host_header(storage) }
+  end
+end


### PR DESCRIPTION
Per the AWS SigV4 spec and RFC 7230, the Host header must include the port when it is not the default for the scheme. The regular request path was always setting Host to just the hostname, causing signature verification failures against S3-compatible servers (e.g. HCP) on non-standard ports. The presigned URL path already handled this correctly; align the request path to match.